### PR TITLE
feat: update server dependencies, remove redundant packages

### DIFF
--- a/packages/server/.eslintrc.js
+++ b/packages/server/.eslintrc.js
@@ -2,12 +2,16 @@ module.exports = {
     env: {
         node: true,
         jest: true,
+        es2022: true,
     },
-    extends: 'airbnb-base',
+    extends: 'eslint:recommended',
     globals: {
       page: true,
       browser: true,
       context: true,
       jestPuppeteer: true,
+    },
+    parserOptions: {
+      ecmaVersion: 2022,
     },
 };

--- a/packages/server/jest.config.js
+++ b/packages/server/jest.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-  setupFiles: ['./jest.setup.js'],
   coverageDirectory: 'coverage',
   collectCoverageFrom: [
     '**/*.{js}',

--- a/packages/server/jest.setup.js
+++ b/packages/server/jest.setup.js
@@ -1,4 +1,0 @@
-// Polyfill TextEncoder/TextDecoder for pg module (needed by Jest 23)
-const { TextEncoder, TextDecoder } = require('util');
-global.TextEncoder = TextEncoder;
-global.TextDecoder = TextDecoder;

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,32 +19,27 @@
     "lint:fix": "eslint --fix src; exit 0",
     "test": "jest --watch",
     "test:coverage": "jest --coverage --detectOpenHandles --forceExit",
-    "test:integration": "cross-env NODE_ENV=integration jest --config jest.integration.config.js --detectOpenHandles --runInBand",
+    "test:integration": "NODE_ENV=integration jest --config jest.integration.config.js --detectOpenHandles --runInBand",
     "watch": "nodemon app.js"
   },
   "dependencies": {
-    "body-parser": "^1.18.3",
     "connect-pg-simple": "^10.0.0",
-    "cookie-parser": "^1.4.4",
-    "dotenv": "^6.2.0",
-    "express": "^4.16.4",
-    "express-session": "^1.15.6",
-    "passport": "^0.4.0",
-    "passport-oauth2-refresh": "^1.1.0",
+    "dotenv": "^17.4.2",
+    "express": "^4.22.1",
+    "express-session": "^1.19.0",
+    "passport": "^0.7.0",
+    "passport-oauth2-refresh": "^2.2.0",
     "passport-spotify": "^1.0.1",
     "pg": "^8.20.0",
     "spotify-web-api-node": "^4.0.0",
-    "winston": "^3.2.1"
+    "winston": "^3.19.0"
   },
   "devDependencies": {
-    "cross-env": "^5.2.0",
-    "eslint": "^5.14.1",
-    "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-plugin-import": "^2.16.0",
-    "jest": "^23.6.0",
-    "jest-puppeteer": "^3.9.0",
-    "nodemon": "^1.18.10",
-    "puppeteer": "^1.13.0",
-    "supertest": "^3.4.2"
+    "eslint": "^8.57.1",
+    "jest": "^30.3.0",
+    "jest-puppeteer": "^11.0.0",
+    "nodemon": "^3.1.14",
+    "puppeteer": "^24.40.0",
+    "supertest": "^7.2.2"
   }
 }

--- a/packages/server/src/initApp.js
+++ b/packages/server/src/initApp.js
@@ -2,12 +2,10 @@ if (process.env.NODE_ENV !== 'production') {
   // Load .env file for variables in dev environments only.
   // The file must be in the server package directory.
   // eslint-disable-next-line global-require
-  require('dotenv').load();
+  require('dotenv').config();
 }
 
 const express = require('express');
-const cookieParser = require('cookie-parser');
-const bodyParser = require('body-parser');
 const session = require('express-session');
 const pgSession = require('connect-pg-simple')(session);
 const passport = require('passport');
@@ -26,11 +24,8 @@ module.exports = function initApp() {
 
   const app = express();
 
-  app.use(cookieParser());
-
-  app.use(bodyParser.urlencoded({
-    extended: false,
-  }));
+  app.use(express.urlencoded({ extended: false }));
+  app.use(express.json());
 
   app.use(session({
     secret: process.env.SESSION_SECRET,

--- a/packages/server/src/routes/auth.js
+++ b/packages/server/src/routes/auth.js
@@ -24,11 +24,13 @@ router.get('/user', (req, res) => {
   });
 });
 
-router.get('/user/logout', (req, res) => {
-  req.logout();
-  // Setting to `null` will clear the session in the DB.
-  req.session = null;
-  res.redirect('/');
+router.get('/user/logout', (req, res, next) => {
+  req.logout((err) => {
+    if (err) { return next(err); }
+    // Setting to `null` will clear the session in the DB.
+    req.session = null;
+    res.redirect('/');
+  });
 });
 
 router.get(


### PR DESCRIPTION
## Summary
- Remove `body-parser`, `cookie-parser`, `cross-env` (replaced by Express built-ins / not needed)
- Remove `eslint-config-airbnb-base` + `eslint-plugin-import`, switch to `eslint:recommended`
- Fix `dotenv.load()` → `dotenv.config()` and `req.logout()` callback
- Remove Jest 23 TextEncoder polyfill (Jest 30 has it natively)
- Update all deps: dotenv 17, express 4.22, passport 0.7, jest 30, eslint 8, nodemon 3, puppeteer 24, supertest 7
- `passport-spotify` and `spotify-web-api-node` left at current versions (Task 4 scope)

## Test plan
- [x] `npm run server:test` — 36/36 tests pass (2 pre-existing suite failures from missing Spotify env vars unchanged)
- [x] `npm run server:lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)