### PR TITLE
feat: add Caddy HTTPS setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,11 +129,11 @@ nano /opt/spune/.env
 
 #### 3. Point your domain to the droplet
 
-In your DNS provider, add an **A record** pointing your domain to the droplet's IP address:
+In your DNS provider, add an **A record** pointing your domain to the droplet's IP address, e.g.:
 
 | Type | Name | Value |
 |------|------|-------|
-| A | `@` (or subdomain) | `YOUR_DROPLET_IP` |
+| A | `@` (or subdomain, like `spune`) | `YOUR_DROPLET_IP` |
 
 Then update `/opt/spune/.env` to use your domain:
 
@@ -178,6 +178,42 @@ After it finishes, add `https://your-domain.com/api/auth/spotify/callback` to yo
 2. CI runs tests, builds, and pushes `ghcr.io/cdtinney/spune:latest`
 3. Watchtower (on your droplet) detects the new image within 60 seconds
 4. It pulls the image and restarts the app container automatically
+
+#### Debugging
+
+Open the **Droplet Console** in the DigitalOcean dashboard, then:
+
+```bash
+cd /opt/spune
+
+# View app logs (last 100 lines)
+docker compose logs --tail 100 app
+
+# Follow logs in real-time
+docker compose logs -f app
+
+# View all container logs
+docker compose logs --tail 100
+
+# Check container status
+docker compose ps
+```
+
+Other useful commands:
+
+```bash
+# Restart everything
+docker compose down && docker compose up -d
+
+# Restart just the app
+docker compose restart app
+
+# Check if the app responds
+curl -s http://localhost:5000/api/auth/user
+
+# Shell into the database
+docker compose exec db psql -U spune -d spune
+```
 
 ## Inspiration
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Edit `.env` and fill in your credentials:
 | `PORT` | No | Server port (default: 5000) |
 | `LAST_FM_API_KEY` | No | Last.fm API key for similar artist discovery |
 
-Add `http://127.0.0.1:3000/api/auth/spotify/callback` to your Spotify app's redirect URIs in the dashboard.
+**Important**: Spotify only supports `127.0.0.1` (not `localhost`) for local development redirect URIs. Add `http://127.0.0.1:3000/api/auth/spotify/callback` to your Spotify app's redirect URIs in the [developer dashboard](https://developer.spotify.com/dashboard).
 
 ### Running (Development)
 
@@ -62,13 +62,15 @@ npm run dev
 
 This starts both the Express server (port 5000) and Vite dev server (port 3000) concurrently. Open `http://127.0.0.1:3000`.
 
+The Vite dev server proxies `/api` requests to the Express server, so the redirect URI must point to port 3000 (not 5000) for the session cookie to work correctly.
+
 ### Testing
 
 ```bash
-npm run client:test        # Client tests (Vitest)
-npm run client:lint         # Client lint (ESLint)
+npm run client:test         # Client tests (Vitest)
+npm run client:lint          # Client lint (ESLint)
 npm run server:test:coverage # Server tests (Jest)
-npm run server:lint         # Server lint (ESLint)
+npm run server:lint          # Server lint (ESLint)
 ```
 
 ### Building
@@ -96,11 +98,11 @@ SPOT_REDIRECT_URI=http://localhost:5000/api/auth/spotify/callback
 SESSION_SECRET=your-secret
 ```
 
-### Production Deployment (DigitalOcean Droplet)
+## Production Deployment (DigitalOcean Droplet)
 
 CI auto-builds and pushes a Docker image to `ghcr.io` on every merge to `master`. Your droplet auto-updates via Watchtower.
 
-#### 1. Set up the droplet
+### 1. Set up the droplet
 
 Create an Ubuntu 24.04 droplet (1GB RAM is enough). Open the **Droplet Console** in the DigitalOcean dashboard and run the setup script:
 
@@ -110,7 +112,7 @@ curl -fsSL https://raw.githubusercontent.com/cdtinney/spune/master/scripts/setup
 
 The script installs Docker, creates `/opt/spune` with a `docker-compose.yml` and `.env`, and generates random secrets.
 
-#### 2. Configure credentials
+### 2. Configure credentials
 
 Log in to GitHub Container Registry so the droplet can pull the Docker image:
 
@@ -127,93 +129,85 @@ Edit `/opt/spune/.env` and fill in your Spotify + Last.fm credentials:
 nano /opt/spune/.env
 ```
 
-#### 3. Point your domain to the droplet
+### 3. Point your domain to the droplet
 
-In your DNS provider, add an **A record** pointing your domain to the droplet's IP address, e.g.:
+In your DNS provider, add an **A record** pointing your domain to the droplet's IP address:
 
 | Type | Name | Value |
 |------|------|-------|
 | A | `@` (or subdomain, like `spune`) | `YOUR_DROPLET_IP` |
 
-Then update `/opt/spune/.env` to use your domain:
+**If using Cloudflare**: set the proxy status to **DNS only** (grey cloud icon, not orange). Caddy handles SSL — Cloudflare's proxy will conflict with it.
 
-```
-SPOT_REDIRECT_URI=https://your-domain.com/api/auth/spotify/callback
-CLIENT_HOST=https://your-domain.com
-```
-
-Also add `https://your-domain.com/api/auth/spotify/callback` to your Spotify app's redirect URIs in the dashboard.
-
-#### 4. Start
+### 4. Start and run migrations
 
 ```bash
 cd /opt/spune
 docker compose up -d
 ```
 
-Wait ~10 seconds for PostgreSQL to initialize, then run the migration:
+Wait for PostgreSQL to be ready, then run migrations:
 
 ```bash
-docker compose exec db psql -U spune -d spune -c \
-  "CREATE TABLE IF NOT EXISTS users (id SERIAL PRIMARY KEY, spotify_id TEXT UNIQUE NOT NULL, spotify_access_token TEXT, spotify_refresh_token TEXT, token_updated BIGINT, expires_in BIGINT, display_name TEXT, photos JSON);"
+curl -fsSL https://raw.githubusercontent.com/cdtinney/spune/master/scripts/migrate.sh | bash
 ```
 
-The app is now running. If you're using a domain with the setup script's default config, it serves on port 80 (HTTP). For HTTPS, see below.
-
-#### 5. Add HTTPS with a custom domain (optional)
-
-The setup script serves on port 80 (HTTP). To add automatic HTTPS with a custom domain, run the Caddy setup script:
+### 5. Add HTTPS with a custom domain
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/cdtinney/spune/master/scripts/setup-caddy.sh | bash -s your-domain.com
 ```
 
-This adds Caddy as a reverse proxy with automatic Let's Encrypt TLS certificates. It also updates `.env` with the correct redirect URIs.
+This adds Caddy as a reverse proxy with automatic Let's Encrypt TLS certificates and updates `.env` with the correct redirect URIs.
 
-After it finishes, add `https://your-domain.com/api/auth/spotify/callback` to your Spotify app's redirect URIs in the dashboard.
+**Don't forget**: add `https://your-domain.com/api/auth/spotify/callback` to your Spotify app's redirect URIs in the [developer dashboard](https://developer.spotify.com/dashboard).
 
-#### How auto-deploy works
+### How auto-deploy works
 
 1. You merge a PR to `master`
 2. CI runs tests, builds, and pushes `ghcr.io/cdtinney/spune:latest`
 3. Watchtower (on your droplet) detects the new image within 60 seconds
 4. It pulls the image and restarts the app container automatically
 
-#### Debugging
+### Debugging
 
 Open the **Droplet Console** in the DigitalOcean dashboard, then:
 
 ```bash
 cd /opt/spune
 
-# View app logs (last 100 lines)
+# View app logs
 docker compose logs --tail 100 app
 
 # Follow logs in real-time
 docker compose logs -f app
 
-# View all container logs
-docker compose logs --tail 100
-
 # Check container status
 docker compose ps
-```
-
-Other useful commands:
-
-```bash
-# Restart everything
-docker compose down && docker compose up -d
-
-# Restart just the app
-docker compose restart app
 
 # Check if the app responds
 curl -s http://localhost:5000/api/auth/user
-
-# Shell into the database
-docker compose exec db psql -U spune -d spune
 ```
+
+### Common issues
+
+**"Internal Server Error" after login**: The Spotify redirect URI in your `.env` doesn't match what's registered in the Spotify dashboard. They must be identical.
+
+**"DB_PASSWORD variable is not set"**: The `.env` file is missing `DB_PASSWORD`. Check with `cat /opt/spune/.env | grep DB_PASSWORD`.
+
+**Database connection errors after changing `DB_PASSWORD`**: Postgres stores the password on first start. If you change it later, you must reset the volume:
+
+```bash
+cd /opt/spune
+docker compose down -v
+docker compose up -d
+# Wait ~10 seconds, then re-run migrations:
+curl -fsSL https://raw.githubusercontent.com/cdtinney/spune/master/scripts/migrate.sh | bash
+```
+
+**Browser security warning on bare IP**: Use a domain with HTTPS (step 5) instead of a bare IP address.
+
+**Login redirects back to home page**: The session cookie isn't being set. Check that `SPOT_REDIRECT_URI` and `CLIENT_HOST` use the same origin (same protocol, domain, and port).
 
 ## Inspiration
 

--- a/README.md
+++ b/README.md
@@ -160,35 +160,17 @@ docker compose exec db psql -U spune -d spune -c \
 
 The app is now running. If you're using a domain with the setup script's default config, it serves on port 80 (HTTP). For HTTPS, see below.
 
-#### HTTPS with Caddy (optional)
+#### 5. Add HTTPS with a custom domain (optional)
 
-The setup script serves on port 80 (HTTP). To add automatic HTTPS, edit `/opt/spune/docker-compose.yml` and add a Caddy service:
+The setup script serves on port 80 (HTTP). To add automatic HTTPS with a custom domain, run the Caddy setup script:
 
-```yaml
-  caddy:
-    image: caddy:2-alpine
-    restart: always
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile
-      - caddy_data:/data
-volumes:
-  caddy_data:
+```bash
+curl -fsSL https://raw.githubusercontent.com/cdtinney/spune/master/scripts/setup-caddy.sh | bash -s your-domain.com
 ```
 
-Change the `app` service ports from `"80:5000"` to `"5000:5000"` (internal only).
+This adds Caddy as a reverse proxy with automatic Let's Encrypt TLS certificates. It also updates `.env` with the correct redirect URIs.
 
-Create `/opt/spune/Caddyfile`:
-
-```
-your-domain.com {
-    reverse_proxy app:5000
-}
-```
-
-Restart: `docker compose down && docker compose up -d`. Caddy auto-provisions a Let's Encrypt TLS certificate.
+After it finishes, add `https://your-domain.com/api/auth/spotify/callback` to your Spotify app's redirect URIs in the dashboard.
 
 #### How auto-deploy works
 

--- a/packages/server/src/initApp.js
+++ b/packages/server/src/initApp.js
@@ -20,16 +20,17 @@ const configurePassport = require('./auth/configurePassport');
 module.exports = function initApp() {
   const app = express();
 
+  // Trust reverse proxy (Caddy) so Express sees correct protocol/IP
+  app.set('trust proxy', 1);
+
   app.use(express.urlencoded({ extended: false }));
   app.use(express.json());
 
   app.use(session({
     secret: process.env.SESSION_SECRET,
     cookie: {
-      // Persist cookies for a year. By default, cookies
-      // are not persistent and will be lost upon certain
-      // conditions like browsers exiting.
       maxAge: 1000 * 60 * 60 * 24 * 365,
+      secure: process.env.NODE_ENV === 'production',
     },
     resave: false,
     saveUninitialized: false,

--- a/scripts/logs.sh
+++ b/scripts/logs.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# View Spune logs on the droplet.
+# Usage:
+#   bash logs.sh          # all containers, last 100 lines
+#   bash logs.sh app      # app only
+#   bash logs.sh db       # database only
+#   bash logs.sh caddy    # caddy only
+#   bash logs.sh -f       # follow (live tail) all containers
+#   bash logs.sh app -f   # follow app only
+
+cd /opt/spune
+SERVICE="${1:-}"
+
+if [ "$SERVICE" = "-f" ]; then
+  docker compose logs --tail 100 -f
+elif [ -n "$SERVICE" ]; then
+  shift
+  docker compose logs --tail 100 "$@" "$SERVICE"
+else
+  docker compose logs --tail 100
+fi

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run all database migrations.
+# Usage (on droplet): bash migrate.sh
+# Usage (local):      bash scripts/migrate.sh
+
+MIGRATIONS_DIR=""
+
+# Detect if running inside the Docker setup or locally
+if [ -d "/opt/spune" ] && docker compose -f /opt/spune/docker-compose.yml ps db >/dev/null 2>&1; then
+  # Running on droplet — execute via docker compose
+  echo "==> Waiting for database..."
+  until docker compose -f /opt/spune/docker-compose.yml exec db pg_isready -U spune >/dev/null 2>&1; do
+    sleep 1
+  done
+
+  echo "==> Running migrations..."
+  for f in /opt/spune/migrations/*.sql 2>/dev/null; do
+    echo "  Applying $(basename "$f")..."
+    docker compose -f /opt/spune/docker-compose.yml exec -T db psql -U spune -d spune < "$f"
+  done
+
+  # Also try from the container's bundled migrations
+  docker compose -f /opt/spune/docker-compose.yml exec -T app sh -c '
+    for f in /app/packages/server/src/database/migrations/*.sql; do
+      echo "  Applying $(basename "$f")..."
+      cat "$f"
+    done
+  ' | docker compose -f /opt/spune/docker-compose.yml exec -T db psql -U spune -d spune
+
+  echo "==> Migrations complete."
+else
+  # Running locally
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+  MIGRATIONS_DIR="$SCRIPT_DIR/../packages/server/src/database/migrations"
+
+  if [ -z "${DATABASE_URL:-}" ]; then
+    echo "Error: DATABASE_URL is not set."
+    echo "Usage: DATABASE_URL=postgresql://... bash scripts/migrate.sh"
+    exit 1
+  fi
+
+  echo "==> Running migrations..."
+  for f in "$MIGRATIONS_DIR"/*.sql; do
+    echo "  Applying $(basename "$f")..."
+    psql "$DATABASE_URL" -f "$f"
+  done
+  echo "==> Migrations complete."
+fi

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -1,38 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Run all database migrations via the app container.
-# Usage (on droplet): curl ... | bash
-# Usage (local):      DATABASE_URL=... bash scripts/migrate.sh
+echo "==> Waiting for database..."
+until docker compose -f /opt/spune/docker-compose.yml exec -T db pg_isready -U spune 2>/dev/null; do
+  sleep 1
+done
 
-CD="/opt/spune"
-DC="docker compose -f ${CD}/docker-compose.yml"
+echo "==> Running migrations..."
+docker compose -f /opt/spune/docker-compose.yml exec -T app \
+  sh -c 'cat /app/packages/server/src/database/migrations/*.sql' \
+  | docker compose -f /opt/spune/docker-compose.yml exec -T db psql -U spune -d spune
 
-if [ -d "$CD" ] && $DC ps db >/dev/null 2>&1; then
-  echo "==> Waiting for database..."
-  until $DC exec -T db pg_isready -U spune >/dev/null 2>&1; do
-    sleep 1
-  done
-
-  echo "==> Running migrations from app container..."
-  $DC exec -T app sh -c 'cat /app/packages/server/src/database/migrations/*.sql' \
-    | $DC exec -T db psql -U spune -d spune
-
-  echo "==> Migrations complete."
-else
-  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-  MIGRATIONS_DIR="$SCRIPT_DIR/../packages/server/src/database/migrations"
-
-  if [ -z "${DATABASE_URL:-}" ]; then
-    echo "Error: DATABASE_URL is not set."
-    echo "Usage: DATABASE_URL=postgresql://... bash scripts/migrate.sh"
-    exit 1
-  fi
-
-  echo "==> Running migrations..."
-  for f in "$MIGRATIONS_DIR"/*.sql; do
-    echo "  Applying $(basename "$f")..."
-    psql "$DATABASE_URL" -f "$f"
-  done
-  echo "==> Migrations complete."
-fi
+echo "==> Migrations complete."

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -1,37 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Run all database migrations.
-# Usage (on droplet): bash migrate.sh
-# Usage (local):      bash scripts/migrate.sh
+# Run all database migrations via the app container.
+# Usage (on droplet): curl ... | bash
+# Usage (local):      DATABASE_URL=... bash scripts/migrate.sh
 
-MIGRATIONS_DIR=""
+CD="/opt/spune"
+DC="docker compose -f ${CD}/docker-compose.yml"
 
-# Detect if running inside the Docker setup or locally
-if [ -d "/opt/spune" ] && docker compose -f /opt/spune/docker-compose.yml ps db >/dev/null 2>&1; then
-  # Running on droplet — execute via docker compose
+if [ -d "$CD" ] && $DC ps db >/dev/null 2>&1; then
   echo "==> Waiting for database..."
-  until docker compose -f /opt/spune/docker-compose.yml exec db pg_isready -U spune >/dev/null 2>&1; do
+  until $DC exec -T db pg_isready -U spune >/dev/null 2>&1; do
     sleep 1
   done
 
-  echo "==> Running migrations..."
-  for f in /opt/spune/migrations/*.sql 2>/dev/null; do
-    echo "  Applying $(basename "$f")..."
-    docker compose -f /opt/spune/docker-compose.yml exec -T db psql -U spune -d spune < "$f"
-  done
-
-  # Also try from the container's bundled migrations
-  docker compose -f /opt/spune/docker-compose.yml exec -T app sh -c '
-    for f in /app/packages/server/src/database/migrations/*.sql; do
-      echo "  Applying $(basename "$f")..."
-      cat "$f"
-    done
-  ' | docker compose -f /opt/spune/docker-compose.yml exec -T db psql -U spune -d spune
+  echo "==> Running migrations from app container..."
+  $DC exec -T app sh -c 'cat /app/packages/server/src/database/migrations/*.sql' \
+    | $DC exec -T db psql -U spune -d spune
 
   echo "==> Migrations complete."
 else
-  # Running locally
   SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
   MIGRATIONS_DIR="$SCRIPT_DIR/../packages/server/src/database/migrations"
 

--- a/scripts/setup-caddy.sh
+++ b/scripts/setup-caddy.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Adds Caddy (HTTPS) to an existing Spune droplet setup.
+# Usage: bash setup-caddy.sh spune.tinney.dev
+
+DOMAIN="${1:-}"
+if [ -z "$DOMAIN" ]; then
+  echo "Usage: bash setup-caddy.sh YOUR_DOMAIN"
+  echo "  e.g. bash setup-caddy.sh spune.tinney.dev"
+  exit 1
+fi
+
+cd /opt/spune
+
+echo "==> Stopping containers..."
+docker compose down
+
+echo "==> Creating Caddyfile for ${DOMAIN}..."
+cat > Caddyfile <<EOF
+${DOMAIN} {
+    reverse_proxy app:5000
+}
+EOF
+
+echo "==> Updating docker-compose.yml..."
+cat > docker-compose.yml <<'COMPOSE'
+services:
+  db:
+    image: postgres:16-alpine
+    restart: always
+    environment:
+      POSTGRES_USER: spune
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: spune
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  app:
+    image: ghcr.io/cdtinney/spune:latest
+    restart: always
+    expose:
+      - "5000"
+    depends_on:
+      - db
+    env_file: .env
+    environment:
+      NODE_ENV: production
+      DATABASE_URL: postgresql://spune:${DB_PASSWORD}@db:5432/spune
+
+  caddy:
+    image: caddy:2-alpine
+    restart: always
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data
+
+  watchtower:
+    image: containrrr/watchtower
+    restart: always
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /root/.docker/config.json:/config.json:ro
+    command: --interval 60 --cleanup
+
+volumes:
+  pgdata:
+  caddy_data:
+COMPOSE
+
+echo "==> Updating .env redirect URIs..."
+sed -i "s|SPOT_REDIRECT_URI=.*|SPOT_REDIRECT_URI=https://${DOMAIN}/api/auth/spotify/callback|" .env
+sed -i "s|CLIENT_HOST=.*|CLIENT_HOST=https://${DOMAIN}|" .env
+
+echo "==> Starting containers..."
+docker compose up -d
+
+echo ""
+echo "============================================"
+echo "  HTTPS setup complete!"
+echo "============================================"
+echo ""
+echo "Your app is now at: https://${DOMAIN}"
+echo ""
+echo "Don't forget to add this redirect URI to your"
+echo "Spotify app in the developer dashboard:"
+echo ""
+echo "  https://${DOMAIN}/api/auth/spotify/callback"
+echo ""


### PR DESCRIPTION
## Summary

- Add `scripts/setup-caddy.sh` — one command to add HTTPS via Caddy to an existing droplet
- Simplify README HTTPS instructions from manual steps to a single curl command

## Usage

```bash
curl -fsSL .../scripts/setup-caddy.sh | bash -s spune.tinney.dev
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)