### PR TITLE
feat: Task 12 — UI improvements

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -146,7 +146,8 @@
       "Bash(mv src/initServer.ts src/startServer.ts)",
       "Bash(SPOT_CLIENT_ID=test SPOT_CLIENT_SECRET=test SPOT_REDIRECT_URI=http://127.0.0.1:3000/auth/spotify/callback DATABASE_URL=postgresql://localhost:5432/spune_test SESSION_SECRET=test pnpm --filter spune-server test)",
       "Bash(SPOT_CLIENT_ID=test SPOT_CLIENT_SECRET=test SPOT_REDIRECT_URI=http://127.0.0.1:3000/auth/spotify/callback DATABASE_URL=postgresql://localhost:5432/spune_test SESSION_SECRET=test pnpm --filter spune-server test:coverage)",
-      "Bash(npx playwright:*)"
+      "Bash(npx playwright:*)",
+      "Bash(with Spotify\" button instead of the misleading \"No song playing\":*)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -147,7 +147,8 @@
       "Bash(SPOT_CLIENT_ID=test SPOT_CLIENT_SECRET=test SPOT_REDIRECT_URI=http://127.0.0.1:3000/auth/spotify/callback DATABASE_URL=postgresql://localhost:5432/spune_test SESSION_SECRET=test pnpm --filter spune-server test)",
       "Bash(SPOT_CLIENT_ID=test SPOT_CLIENT_SECRET=test SPOT_REDIRECT_URI=http://127.0.0.1:3000/auth/spotify/callback DATABASE_URL=postgresql://localhost:5432/spune_test SESSION_SECRET=test pnpm --filter spune-server test:coverage)",
       "Bash(npx playwright:*)",
-      "Bash(with Spotify\" button instead of the misleading \"No song playing\":*)"
+      "Bash(with Spotify\" button instead of the misleading \"No song playing\":*)",
+      "Bash(find /Users/ctinney/Development/_Personal/spune -path */colorthief/package.json -not -path */node_modules/.pnpm/*)"
     ]
   }
 }

--- a/packages/client/src/components/AlbumGrid.css
+++ b/packages/client/src/components/AlbumGrid.css
@@ -9,8 +9,10 @@
 
 .album-grid {
   display: grid;
-  animation: mosaic-drift 120s ease-in-out infinite alternate;
+  animation: mosaic-drift 180s cubic-bezier(0.37, 0, 0.63, 1) infinite alternate;
   will-change: transform;
+  transform: translate3d(0, 0, 0);
+  backface-visibility: hidden;
 }
 
 .album-grid__tile {
@@ -24,21 +26,24 @@
   display: block;
 }
 
-/* Slow diagonal drift — moves in all 4 directions over the cycle */
+/* Slow diagonal drift through multiple waypoints for organic movement */
 @keyframes mosaic-drift {
   0% {
-    transform: translate(0, 0);
+    transform: translate3d(0, 0, 0);
   }
-  25% {
-    transform: translate(-8%, -5%);
+  20% {
+    transform: translate3d(-6%, -4%, 0);
   }
-  50% {
-    transform: translate(-15%, -2%);
+  40% {
+    transform: translate3d(-12%, -1%, 0);
   }
-  75% {
-    transform: translate(-5%, -10%);
+  60% {
+    transform: translate3d(-4%, -9%, 0);
+  }
+  80% {
+    transform: translate3d(-10%, -6%, 0);
   }
   100% {
-    transform: translate(-12%, -8%);
+    transform: translate3d(-8%, -10%, 0);
   }
 }

--- a/packages/client/src/components/AlbumGrid.tsx
+++ b/packages/client/src/components/AlbumGrid.tsx
@@ -41,15 +41,35 @@ export default function AlbumGrid({ tiles, gridCols, gridRows, base }: AlbumGrid
     const visIdx = Math.floor(Math.random() * visibleTileIndices.length);
     const tileIndex = visibleTileIndices[visIdx];
 
-    // Pick the next image, skip if same as current
-    let nextImage = allImageUrls[imagePoolRef.current % allImageUrls.length];
-    imagePoolRef.current++;
-    if (nextImage === tiles[tileIndex].imageUrl) {
-      nextImage = allImageUrls[imagePoolRef.current % allImageUrls.length];
+    // Build a set of images currently visible on screen
+    const visibleImages = new Set(
+      visibleTileIndices.map((i) => tiles[i].imageUrl).filter(Boolean),
+    );
+
+    // Find an image that's not already visible
+    let nextImage: string | undefined;
+    for (let attempt = 0; attempt < allImageUrls.length; attempt++) {
+      const candidate = allImageUrls[imagePoolRef.current % allImageUrls.length];
       imagePoolRef.current++;
+      if (!visibleImages.has(candidate)) {
+        nextImage = candidate;
+        break;
+      }
     }
 
-    setCurrentFlip({ tileIndex, imageUrl: nextImage });
+    // Fallback: if all images are visible, just pick the next one that's different from this tile
+    if (!nextImage) {
+      nextImage = allImageUrls[imagePoolRef.current % allImageUrls.length];
+      imagePoolRef.current++;
+      if (nextImage === tiles[tileIndex].imageUrl) {
+        nextImage = allImageUrls[imagePoolRef.current % allImageUrls.length];
+        imagePoolRef.current++;
+      }
+    }
+
+    if (nextImage) {
+      setCurrentFlip({ tileIndex, imageUrl: nextImage });
+    }
   }, [tiles, allImageUrls, visibleTileIndices]);
 
   useEffect(() => {

--- a/packages/client/src/components/AlbumGrid.tsx
+++ b/packages/client/src/components/AlbumGrid.tsx
@@ -10,21 +10,24 @@ interface AlbumGridProps {
   base: number;
 }
 
-interface FlipState {
-  tileIndex: number;
-  imageUrl: string;
+interface FlipEntry {
+  url: string;
+  key: number;
 }
 
+type FlipMap = Record<number, FlipEntry>;
+
 export default function AlbumGrid({ tiles, gridCols, gridRows, base }: AlbumGridProps) {
-  const [currentFlip, setCurrentFlip] = useState<FlipState | null>(null);
+  const [flipMap, setFlipMap] = useState<FlipMap>({});
   const imagePoolRef = useRef(0);
+  const flipCounterRef = useRef(1);
+  const prevTileIdsRef = useRef('');
 
   const allImageUrls = useMemo(
     () => tiles.map((t) => t.imageUrl).filter((url): url is string => !!url),
     [tiles],
   );
 
-  // Indices of tiles that are roughly within the viewport
   const visibleTileIndices = useMemo(() => {
     const maxCol = Math.ceil(window.innerWidth / base) + 2;
     const maxRow = Math.ceil(window.innerHeight / base) + 2;
@@ -34,19 +37,47 @@ export default function AlbumGrid({ tiles, gridCols, gridRows, base }: AlbumGrid
       .map(({ index }) => index);
   }, [tiles, base]);
 
+  // Cascade flip on song change
+  useEffect(() => {
+    const currentIds = allImageUrls.slice(0, 20).join(',');
+    if (currentIds === prevTileIdsRef.current || tiles.length === 0) {
+      prevTileIdsRef.current = currentIds;
+      return;
+    }
+
+    const isFirstLoad = prevTileIdsRef.current === '';
+    prevTileIdsRef.current = currentIds;
+
+    if (isFirstLoad) return;
+
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    const shuffled = [...visibleTileIndices].sort(() => Math.random() - 0.5);
+
+    shuffled.forEach((tileIndex, i) => {
+      const timer = setTimeout(() => {
+        const newImage = tiles[tileIndex]?.imageUrl;
+        if (newImage) {
+          const key = flipCounterRef.current++;
+          setFlipMap((prev) => ({ ...prev, [tileIndex]: { url: newImage, key } }));
+        }
+      }, i * 50);
+      timers.push(timer);
+    });
+
+    return () => timers.forEach(clearTimeout);
+  }, [allImageUrls, tiles, visibleTileIndices]);
+
+  // Ambient random flip
   const flipRandomTile = useCallback(() => {
     if (visibleTileIndices.length === 0 || allImageUrls.length === 0) return;
 
-    // Pick a random visible tile
     const visIdx = Math.floor(Math.random() * visibleTileIndices.length);
     const tileIndex = visibleTileIndices[visIdx];
 
-    // Build a set of images currently visible on screen
     const visibleImages = new Set(
       visibleTileIndices.map((i) => tiles[i].imageUrl).filter(Boolean),
     );
 
-    // Find an image that's not already visible
     let nextImage: string | undefined;
     for (let attempt = 0; attempt < allImageUrls.length; attempt++) {
       const candidate = allImageUrls[imagePoolRef.current % allImageUrls.length];
@@ -57,31 +88,22 @@ export default function AlbumGrid({ tiles, gridCols, gridRows, base }: AlbumGrid
       }
     }
 
-    // Fallback: if all images are visible, just pick the next one that's different from this tile
     if (!nextImage) {
       nextImage = allImageUrls[imagePoolRef.current % allImageUrls.length];
       imagePoolRef.current++;
-      if (nextImage === tiles[tileIndex].imageUrl) {
-        nextImage = allImageUrls[imagePoolRef.current % allImageUrls.length];
-        imagePoolRef.current++;
-      }
     }
 
     if (nextImage) {
-      setCurrentFlip({ tileIndex, imageUrl: nextImage });
+      const key = flipCounterRef.current++;
+      setFlipMap((prev) => ({ ...prev, [tileIndex]: { url: nextImage!, key } }));
     }
   }, [tiles, allImageUrls, visibleTileIndices]);
 
   useEffect(() => {
     if (tiles.length === 0) return;
 
-    // First flip after 7 seconds, then every 7-10 seconds
     const firstTimeout = setTimeout(flipRandomTile, 7000);
-
-    const interval = setInterval(
-      flipRandomTile,
-      7000 + Math.random() * 3000,
-    );
+    const interval = setInterval(flipRandomTile, 7000 + Math.random() * 3000);
 
     return () => {
       clearTimeout(firstTimeout);
@@ -102,22 +124,30 @@ export default function AlbumGrid({ tiles, gridCols, gridRows, base }: AlbumGrid
           gridTemplateRows: `repeat(${gridRows}, ${base}px)`,
         }}
       >
-        {tiles.map((tile, index) => (
-          <div
-            key={tile.id}
-            className="album-grid__tile"
-            style={{
-              gridColumn: `${tile.col} / span ${tile.span}`,
-              gridRow: `${tile.row} / span ${tile.span}`,
-            }}
-          >
-            <FlippableTile
-              src={tile.imageUrl}
-              alt={tile.title}
-              flipToSrc={currentFlip?.tileIndex === index ? currentFlip.imageUrl : null}
-            />
-          </div>
-        ))}
+        {tiles.map((tile, index) => {
+          const isVisible = visibleTileIndices.includes(index);
+          const entranceDelay = isVisible ? index * 15 : 0;
+          const flip = flipMap[index];
+
+          return (
+            <div
+              key={tile.id}
+              className="album-grid__tile"
+              style={{
+                gridColumn: `${tile.col} / span ${tile.span}`,
+                gridRow: `${tile.row} / span ${tile.span}`,
+              }}
+            >
+              <FlippableTile
+                src={tile.imageUrl}
+                alt={tile.title}
+                flipToSrc={flip?.url ?? null}
+                flipKey={flip?.key ?? 0}
+                entranceDelay={entranceDelay}
+              />
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/packages/client/src/components/AlbumGrid.tsx
+++ b/packages/client/src/components/AlbumGrid.tsx
@@ -1,4 +1,5 @@
-import AlbumImage from './AlbumImage';
+import { useMemo } from 'react';
+import FlippableTile from './FlippableTile';
 import type { Album } from '../types';
 import './AlbumGrid.css';
 
@@ -10,6 +11,12 @@ interface AlbumGridProps {
 }
 
 export default function AlbumGrid({ tiles, gridCols, gridRows, base }: AlbumGridProps) {
+  // Build a pool of all image URLs for tile flipping
+  const allImageUrls = useMemo(
+    () => tiles.map((t) => t.imageUrl).filter((url): url is string => !!url),
+    [tiles],
+  );
+
   if (!tiles || !tiles.length) {
     return null;
   }
@@ -23,18 +30,29 @@ export default function AlbumGrid({ tiles, gridCols, gridRows, base }: AlbumGrid
           gridTemplateRows: `repeat(${gridRows}, ${base}px)`,
         }}
       >
-        {tiles.map((tile) => (
-          <div
-            key={tile.id}
-            className="album-grid__tile"
-            style={{
-              gridColumn: `${tile.col} / span ${tile.span}`,
-              gridRow: `${tile.row} / span ${tile.span}`,
-            }}
-          >
-            <AlbumImage src={tile.imageUrl} alt={tile.title} />
-          </div>
-        ))}
+        {tiles.map((tile, index) => {
+          // ~15% of tiles flip, with staggered intervals (8-20s)
+          const shouldFlip = (index * 7 + 3) % 7 === 0;
+          const flipInterval = shouldFlip ? 8000 + ((index * 13) % 12) * 1000 : 0;
+
+          return (
+            <div
+              key={tile.id}
+              className="album-grid__tile"
+              style={{
+                gridColumn: `${tile.col} / span ${tile.span}`,
+                gridRow: `${tile.row} / span ${tile.span}`,
+              }}
+            >
+              <FlippableTile
+                frontSrc={tile.imageUrl}
+                frontAlt={tile.title}
+                extraImages={allImageUrls}
+                flipInterval={flipInterval}
+              />
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/packages/client/src/components/AlbumGrid.tsx
+++ b/packages/client/src/components/AlbumGrid.tsx
@@ -32,7 +32,7 @@ export default function AlbumGrid({ tiles, gridCols, gridRows, base }: AlbumGrid
       >
         {tiles.map((tile, index) => {
           // ~15% of tiles flip, with staggered intervals (8-20s)
-          const shouldFlip = (index * 7 + 3) % 7 === 0;
+          const shouldFlip = index % 7 === 0;
           const flipInterval = shouldFlip ? 8000 + ((index * 13) % 12) * 1000 : 0;
 
           return (

--- a/packages/client/src/components/AlbumGrid.tsx
+++ b/packages/client/src/components/AlbumGrid.tsx
@@ -24,12 +24,24 @@ export default function AlbumGrid({ tiles, gridCols, gridRows, base }: AlbumGrid
     [tiles],
   );
 
-  const flipRandomTile = useCallback(() => {
-    if (tiles.length === 0 || allImageUrls.length === 0) return;
+  // Indices of tiles that are roughly within the viewport
+  const visibleTileIndices = useMemo(() => {
+    const maxCol = Math.ceil(window.innerWidth / base) + 2;
+    const maxRow = Math.ceil(window.innerHeight / base) + 2;
+    return tiles
+      .map((tile, index) => ({ tile, index }))
+      .filter(({ tile }) => tile.col <= maxCol && tile.row <= maxRow)
+      .map(({ index }) => index);
+  }, [tiles, base]);
 
-    // Pick a random tile
-    const tileIndex = Math.floor(Math.random() * tiles.length);
-    // Pick the next image from the pool (cycling), skip if it's the same as the tile's current image
+  const flipRandomTile = useCallback(() => {
+    if (visibleTileIndices.length === 0 || allImageUrls.length === 0) return;
+
+    // Pick a random visible tile
+    const visIdx = Math.floor(Math.random() * visibleTileIndices.length);
+    const tileIndex = visibleTileIndices[visIdx];
+
+    // Pick the next image, skip if same as current
     let nextImage = allImageUrls[imagePoolRef.current % allImageUrls.length];
     imagePoolRef.current++;
     if (nextImage === tiles[tileIndex].imageUrl) {
@@ -38,24 +50,23 @@ export default function AlbumGrid({ tiles, gridCols, gridRows, base }: AlbumGrid
     }
 
     setCurrentFlip({ tileIndex, imageUrl: nextImage });
-  }, [tiles, allImageUrls]);
+  }, [tiles, allImageUrls, visibleTileIndices]);
 
   useEffect(() => {
     if (tiles.length === 0) return;
 
-    // First flip after 10 seconds, then every 10-15 seconds
-    const firstTimeout = setTimeout(() => {
-      flipRandomTile();
+    // First flip after 7 seconds, then every 7-10 seconds
+    const firstTimeout = setTimeout(flipRandomTile, 7000);
 
-      const interval = setInterval(
-        () => flipRandomTile(),
-        10000 + Math.random() * 5000,
-      );
+    const interval = setInterval(
+      flipRandomTile,
+      7000 + Math.random() * 3000,
+    );
 
-      return () => clearInterval(interval);
-    }, 10000);
-
-    return () => clearTimeout(firstTimeout);
+    return () => {
+      clearTimeout(firstTimeout);
+      clearInterval(interval);
+    };
   }, [tiles.length, flipRandomTile]);
 
   if (!tiles || !tiles.length) {

--- a/packages/client/src/components/AlbumGrid.tsx
+++ b/packages/client/src/components/AlbumGrid.tsx
@@ -74,9 +74,7 @@ export default function AlbumGrid({ tiles, gridCols, gridRows, base }: AlbumGrid
     const visIdx = Math.floor(Math.random() * visibleTileIndices.length);
     const tileIndex = visibleTileIndices[visIdx];
 
-    const visibleImages = new Set(
-      visibleTileIndices.map((i) => tiles[i].imageUrl).filter(Boolean),
-    );
+    const visibleImages = new Set(visibleTileIndices.map((i) => tiles[i].imageUrl).filter(Boolean));
 
     let nextImage: string | undefined;
     for (let attempt = 0; attempt < allImageUrls.length; attempt++) {

--- a/packages/client/src/components/AlbumGrid.tsx
+++ b/packages/client/src/components/AlbumGrid.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import FlippableTile from './FlippableTile';
 import type { Album } from '../types';
 import './AlbumGrid.css';
@@ -10,12 +10,53 @@ interface AlbumGridProps {
   base: number;
 }
 
+interface FlipState {
+  tileIndex: number;
+  imageUrl: string;
+}
+
 export default function AlbumGrid({ tiles, gridCols, gridRows, base }: AlbumGridProps) {
-  // Build a pool of all image URLs for tile flipping
+  const [currentFlip, setCurrentFlip] = useState<FlipState | null>(null);
+  const imagePoolRef = useRef(0);
+
   const allImageUrls = useMemo(
     () => tiles.map((t) => t.imageUrl).filter((url): url is string => !!url),
     [tiles],
   );
+
+  const flipRandomTile = useCallback(() => {
+    if (tiles.length === 0 || allImageUrls.length === 0) return;
+
+    // Pick a random tile
+    const tileIndex = Math.floor(Math.random() * tiles.length);
+    // Pick the next image from the pool (cycling), skip if it's the same as the tile's current image
+    let nextImage = allImageUrls[imagePoolRef.current % allImageUrls.length];
+    imagePoolRef.current++;
+    if (nextImage === tiles[tileIndex].imageUrl) {
+      nextImage = allImageUrls[imagePoolRef.current % allImageUrls.length];
+      imagePoolRef.current++;
+    }
+
+    setCurrentFlip({ tileIndex, imageUrl: nextImage });
+  }, [tiles, allImageUrls]);
+
+  useEffect(() => {
+    if (tiles.length === 0) return;
+
+    // First flip after 10 seconds, then every 10-15 seconds
+    const firstTimeout = setTimeout(() => {
+      flipRandomTile();
+
+      const interval = setInterval(
+        () => flipRandomTile(),
+        10000 + Math.random() * 5000,
+      );
+
+      return () => clearInterval(interval);
+    }, 10000);
+
+    return () => clearTimeout(firstTimeout);
+  }, [tiles.length, flipRandomTile]);
 
   if (!tiles || !tiles.length) {
     return null;
@@ -30,29 +71,22 @@ export default function AlbumGrid({ tiles, gridCols, gridRows, base }: AlbumGrid
           gridTemplateRows: `repeat(${gridRows}, ${base}px)`,
         }}
       >
-        {tiles.map((tile, index) => {
-          // ~15% of tiles flip, with staggered intervals (8-20s)
-          const shouldFlip = index % 7 === 0;
-          const flipInterval = shouldFlip ? 8000 + ((index * 13) % 12) * 1000 : 0;
-
-          return (
-            <div
-              key={tile.id}
-              className="album-grid__tile"
-              style={{
-                gridColumn: `${tile.col} / span ${tile.span}`,
-                gridRow: `${tile.row} / span ${tile.span}`,
-              }}
-            >
-              <FlippableTile
-                frontSrc={tile.imageUrl}
-                frontAlt={tile.title}
-                extraImages={allImageUrls}
-                flipInterval={flipInterval}
-              />
-            </div>
-          );
-        })}
+        {tiles.map((tile, index) => (
+          <div
+            key={tile.id}
+            className="album-grid__tile"
+            style={{
+              gridColumn: `${tile.col} / span ${tile.span}`,
+              gridRow: `${tile.row} / span ${tile.span}`,
+            }}
+          >
+            <FlippableTile
+              src={tile.imageUrl}
+              alt={tile.title}
+              flipToSrc={currentFlip?.tileIndex === index ? currentFlip.imageUrl : null}
+            />
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/packages/client/src/components/CoverOverlay.css
+++ b/packages/client/src/components/CoverOverlay.css
@@ -32,7 +32,9 @@
 .cover-overlay__color {
   position: absolute;
   inset: 0;
-  transition: background 3s ease-in-out, opacity 3s ease-in-out;
+  transition:
+    background 3s ease-in-out,
+    opacity 3s ease-in-out;
 }
 
 .cover-overlay__darken {

--- a/packages/client/src/components/CoverOverlay.css
+++ b/packages/client/src/components/CoverOverlay.css
@@ -3,6 +3,12 @@
   width: 100%;
   height: 100%;
   z-index: 1;
+  pointer-events: none;
+}
+
+.cover-overlay__gradient {
+  position: absolute;
+  inset: 0;
   background: linear-gradient(
     -45deg,
     #ee7752,
@@ -18,18 +24,20 @@
     #e73c7e,
     #ee7752
   );
-  opacity: 0.75;
+  opacity: 0.6;
   background-size: 1200% 1200%;
   animation: move-background 360s ease infinite alternate;
-  pointer-events: none;
+}
+
+.cover-overlay__color {
+  position: absolute;
+  inset: 0;
+  transition: background 3s ease-in-out, opacity 3s ease-in-out;
 }
 
 .cover-overlay__darken {
   position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  inset: 0;
   background: radial-gradient(
     ellipse at center,
     rgba(0, 0, 0, 0.3) 0,

--- a/packages/client/src/components/CoverOverlay.tsx
+++ b/packages/client/src/components/CoverOverlay.tsx
@@ -1,8 +1,21 @@
 import './CoverOverlay.css';
 
-export default function CoverOverlay() {
+interface CoverOverlayProps {
+  dominantColor?: string | null;
+}
+
+export default function CoverOverlay({ dominantColor }: CoverOverlayProps) {
+  const overlayStyle = dominantColor
+    ? {
+        background: `radial-gradient(ellipse at center, ${dominantColor} 0%, transparent 70%)`,
+        opacity: 0.4,
+      }
+    : undefined;
+
   return (
     <div className="cover-overlay">
+      <div className="cover-overlay__gradient" />
+      {dominantColor && <div className="cover-overlay__color" style={overlayStyle} />}
       <div className="cover-overlay__darken" />
     </div>
   );

--- a/packages/client/src/components/FlippableTile.css
+++ b/packages/client/src/components/FlippableTile.css
@@ -3,6 +3,12 @@
   height: 100%;
   position: relative;
   perspective: 800px;
+  opacity: 0;
+  transition: opacity 0.6s ease-in;
+}
+
+.flippable-tile--entered {
+  opacity: 1;
 }
 
 .flippable-tile__face {

--- a/packages/client/src/components/FlippableTile.css
+++ b/packages/client/src/components/FlippableTile.css
@@ -1,0 +1,36 @@
+.flippable-tile {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  perspective: 800px;
+}
+
+.flippable-tile__face {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  transition: transform 0.8s ease-in-out;
+}
+
+.flippable-tile__face img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.flippable-tile__front {
+  transform: rotateY(0deg);
+}
+
+.flippable-tile__back {
+  transform: rotateY(180deg);
+}
+
+.flippable-tile--flipped .flippable-tile__front {
+  transform: rotateY(-180deg);
+}
+
+.flippable-tile--flipped .flippable-tile__back {
+  transform: rotateY(0deg);
+}

--- a/packages/client/src/components/FlippableTile.tsx
+++ b/packages/client/src/components/FlippableTile.tsx
@@ -4,21 +4,31 @@ import './FlippableTile.css';
 interface FlippableTileProps {
   src: string | undefined;
   alt: string;
-  flipToSrc: string | null; // when this changes to a new value, the tile flips
+  flipToSrc: string | null;
+  flipKey: number; // increment to trigger a flip
+  entranceDelay?: number;
 }
 
-export default function FlippableTile({ src, alt, flipToSrc }: FlippableTileProps) {
+export default function FlippableTile({
+  src,
+  alt,
+  flipToSrc,
+  flipKey,
+  entranceDelay = 0,
+}: FlippableTileProps) {
   const [flipped, setFlipped] = useState(false);
   const [frontSrc, setFrontSrc] = useState(src);
   const [backSrc, setBackSrc] = useState(src);
+  const [entered, setEntered] = useState(entranceDelay === 0);
 
   useEffect(() => {
-    setFrontSrc(src);
-    setFlipped(false);
-  }, [src]);
+    if (entered) return;
+    const timer = setTimeout(() => setEntered(true), entranceDelay);
+    return () => clearTimeout(timer);
+  }, [entranceDelay, entered]);
 
   useEffect(() => {
-    if (!flipToSrc) return;
+    if (flipKey === 0 || !flipToSrc) return;
 
     if (flipped) {
       setFrontSrc(flipToSrc);
@@ -29,10 +39,12 @@ export default function FlippableTile({ src, alt, flipToSrc }: FlippableTileProp
     requestAnimationFrame(() => {
       setFlipped((f) => !f);
     });
-  }, [flipToSrc]);
+  }, [flipKey]);
 
   return (
-    <div className={`flippable-tile ${flipped ? 'flippable-tile--flipped' : ''}`}>
+    <div
+      className={`flippable-tile${flipped ? ' flippable-tile--flipped' : ''}${entered ? ' flippable-tile--entered' : ''}`}
+    >
       <div className="flippable-tile__face flippable-tile__front">
         <img src={frontSrc} alt={alt} loading="lazy" />
       </div>

--- a/packages/client/src/components/FlippableTile.tsx
+++ b/packages/client/src/components/FlippableTile.tsx
@@ -1,0 +1,61 @@
+import { useState, useEffect, useRef } from 'react';
+import './FlippableTile.css';
+
+interface FlippableTileProps {
+  frontSrc: string | undefined;
+  frontAlt: string;
+  extraImages: string[];
+  flipInterval: number; // ms between flips, 0 = never flip
+}
+
+export default function FlippableTile({
+  frontSrc,
+  frontAlt,
+  extraImages,
+  flipInterval,
+}: FlippableTileProps) {
+  const [flipped, setFlipped] = useState(false);
+  const [currentFrontSrc, setCurrentFrontSrc] = useState(frontSrc);
+  const [currentBackSrc, setCurrentBackSrc] = useState(frontSrc);
+  const imageIndexRef = useRef(0);
+
+  useEffect(() => {
+    setCurrentFrontSrc(frontSrc);
+    setCurrentBackSrc(frontSrc);
+  }, [frontSrc]);
+
+  useEffect(() => {
+    if (flipInterval === 0 || extraImages.length === 0) return;
+
+    const timer = setInterval(() => {
+      // Pick the next image from the pool
+      const nextSrc = extraImages[imageIndexRef.current % extraImages.length];
+      imageIndexRef.current++;
+
+      // Set the next image on the hidden face, then flip
+      if (flipped) {
+        setCurrentFrontSrc(nextSrc);
+      } else {
+        setCurrentBackSrc(nextSrc);
+      }
+
+      // Small delay to let the src update before flipping
+      requestAnimationFrame(() => {
+        setFlipped((f) => !f);
+      });
+    }, flipInterval);
+
+    return () => clearInterval(timer);
+  }, [flipInterval, extraImages, flipped]);
+
+  return (
+    <div className={`flippable-tile ${flipped ? 'flippable-tile--flipped' : ''}`}>
+      <div className="flippable-tile__face flippable-tile__front">
+        <img src={currentFrontSrc} alt={frontAlt} loading="lazy" />
+      </div>
+      <div className="flippable-tile__face flippable-tile__back">
+        <img src={currentBackSrc} alt={frontAlt} loading="lazy" />
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/components/FlippableTile.tsx
+++ b/packages/client/src/components/FlippableTile.tsx
@@ -1,60 +1,43 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import './FlippableTile.css';
 
 interface FlippableTileProps {
-  frontSrc: string | undefined;
-  frontAlt: string;
-  extraImages: string[];
-  flipInterval: number; // ms between flips, 0 = never flip
+  src: string | undefined;
+  alt: string;
+  flipToSrc: string | null; // when this changes to a new value, the tile flips
 }
 
-export default function FlippableTile({
-  frontSrc,
-  frontAlt,
-  extraImages,
-  flipInterval,
-}: FlippableTileProps) {
+export default function FlippableTile({ src, alt, flipToSrc }: FlippableTileProps) {
   const [flipped, setFlipped] = useState(false);
-  const [currentFrontSrc, setCurrentFrontSrc] = useState(frontSrc);
-  const [currentBackSrc, setCurrentBackSrc] = useState(frontSrc);
-  const imageIndexRef = useRef(0);
+  const [frontSrc, setFrontSrc] = useState(src);
+  const [backSrc, setBackSrc] = useState(src);
 
   useEffect(() => {
-    setCurrentFrontSrc(frontSrc);
-    setCurrentBackSrc(frontSrc);
-  }, [frontSrc]);
+    setFrontSrc(src);
+    setFlipped(false);
+  }, [src]);
 
   useEffect(() => {
-    if (flipInterval === 0 || extraImages.length === 0) return;
+    if (!flipToSrc) return;
 
-    const timer = setInterval(() => {
-      // Pick the next image from the pool
-      const nextSrc = extraImages[imageIndexRef.current % extraImages.length];
-      imageIndexRef.current++;
+    if (flipped) {
+      setFrontSrc(flipToSrc);
+    } else {
+      setBackSrc(flipToSrc);
+    }
 
-      // Set the next image on the hidden face, then flip
-      if (flipped) {
-        setCurrentFrontSrc(nextSrc);
-      } else {
-        setCurrentBackSrc(nextSrc);
-      }
-
-      // Small delay to let the src update before flipping
-      requestAnimationFrame(() => {
-        setFlipped((f) => !f);
-      });
-    }, flipInterval);
-
-    return () => clearInterval(timer);
-  }, [flipInterval, extraImages, flipped]);
+    requestAnimationFrame(() => {
+      setFlipped((f) => !f);
+    });
+  }, [flipToSrc]);
 
   return (
     <div className={`flippable-tile ${flipped ? 'flippable-tile--flipped' : ''}`}>
       <div className="flippable-tile__face flippable-tile__front">
-        <img src={currentFrontSrc} alt={frontAlt} loading="lazy" />
+        <img src={frontSrc} alt={alt} loading="lazy" />
       </div>
       <div className="flippable-tile__face flippable-tile__back">
-        <img src={currentBackSrc} alt={frontAlt} loading="lazy" />
+        <img src={backSrc} alt={alt} loading="lazy" />
       </div>
     </div>
   );

--- a/packages/client/src/components/FullscreenButton.css
+++ b/packages/client/src/components/FullscreenButton.css
@@ -4,12 +4,22 @@
   bottom: 30px;
   z-index: 100;
   cursor: pointer;
+  background: none;
+  border: none;
+  padding: 8px;
 }
 
 .fullscreen-button__icon {
   color: rgba(255, 255, 255, 0.87);
 }
 
-.fullscreen-button__icon:hover {
+.fullscreen-button:hover .fullscreen-button__icon,
+.fullscreen-button:focus-visible .fullscreen-button__icon {
   color: rgba(255, 255, 255, 0.54);
+}
+
+.fullscreen-button:focus-visible {
+  outline: 2px solid #1db954;
+  outline-offset: 2px;
+  border-radius: 4px;
 }

--- a/packages/client/src/components/FullscreenButton.tsx
+++ b/packages/client/src/components/FullscreenButton.tsx
@@ -8,13 +8,13 @@ interface FullscreenButtonProps {
 
 export default function FullscreenButton({ onClick }: FullscreenButtonProps) {
   return (
-    <div className="fullscreen-button">
-      <FontAwesomeIcon
-        icon={faExpand}
-        size="1x"
-        className="fullscreen-button__icon"
-        onClick={onClick}
-      />
-    </div>
+    <button
+      className="fullscreen-button"
+      onClick={onClick}
+      aria-label="Toggle fullscreen"
+      title="Toggle fullscreen"
+    >
+      <FontAwesomeIcon icon={faExpand} size="1x" className="fullscreen-button__icon" />
+    </button>
   );
 }

--- a/packages/client/src/components/ProgressBar.css
+++ b/packages/client/src/components/ProgressBar.css
@@ -8,7 +8,7 @@
   align-items: center;
   gap: 8px;
   padding: 0 0 8px;
-  max-width: 200px;
+  max-width: 250px;
   width: 100%;
   pointer-events: none;
 }
@@ -17,10 +17,11 @@
   font-size: 0.7rem;
   color: rgba(255, 255, 255, 0.5);
   font-variant-numeric: tabular-nums;
-  min-width: 32px;
+  width: 32px;
+  flex-shrink: 0;
 }
 
-.progress-bar__time:last-child {
+.progress-bar__time:first-child {
   text-align: right;
 }
 

--- a/packages/client/src/components/ProgressBar.css
+++ b/packages/client/src/components/ProgressBar.css
@@ -1,0 +1,38 @@
+.progress-bar {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 20px 8px;
+  pointer-events: none;
+}
+
+.progress-bar__time {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.5);
+  font-variant-numeric: tabular-nums;
+  min-width: 32px;
+}
+
+.progress-bar__time:last-child {
+  text-align: right;
+}
+
+.progress-bar__track {
+  flex: 1;
+  height: 2px;
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 1px;
+  overflow: hidden;
+}
+
+.progress-bar__fill {
+  height: 100%;
+  background: rgba(255, 255, 255, 0.4);
+  border-radius: 1px;
+  transition: width 3s linear;
+}

--- a/packages/client/src/components/ProgressBar.css
+++ b/packages/client/src/components/ProgressBar.css
@@ -37,5 +37,5 @@
   height: 100%;
   background: rgba(255, 255, 255, 0.4);
   border-radius: 1px;
-  transition: width 3s linear;
+  transition: width 0.3s linear;
 }

--- a/packages/client/src/components/ProgressBar.css
+++ b/packages/client/src/components/ProgressBar.css
@@ -1,13 +1,15 @@
 .progress-bar {
   position: absolute;
   bottom: 0;
-  left: 0;
-  right: 0;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 100;
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 0 20px 8px;
+  gap: 8px;
+  padding: 0 0 8px;
+  max-width: 200px;
+  width: 100%;
   pointer-events: none;
 }
 

--- a/packages/client/src/components/ProgressBar.css
+++ b/packages/client/src/components/ProgressBar.css
@@ -7,7 +7,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 0 0 8px;
+  padding: 0 0 35px;
   max-width: 250px;
   width: 100%;
   pointer-events: none;

--- a/packages/client/src/components/ProgressBar.tsx
+++ b/packages/client/src/components/ProgressBar.tsx
@@ -1,0 +1,30 @@
+import './ProgressBar.css';
+
+interface ProgressBarProps {
+  progressMs: number;
+  durationMs: number;
+}
+
+function formatTime(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+export default function ProgressBar({ progressMs, durationMs }: ProgressBarProps) {
+  const percent = durationMs > 0 ? (progressMs / durationMs) * 100 : 0;
+
+  return (
+    <div className="progress-bar">
+      <span className="progress-bar__time">{formatTime(progressMs)}</span>
+      <div className="progress-bar__track">
+        <div
+          className="progress-bar__fill"
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+      <span className="progress-bar__time">{formatTime(durationMs)}</span>
+    </div>
+  );
+}

--- a/packages/client/src/components/ProgressBar.tsx
+++ b/packages/client/src/components/ProgressBar.tsx
@@ -1,8 +1,10 @@
+import { useState, useEffect, useRef } from 'react';
 import './ProgressBar.css';
 
 interface ProgressBarProps {
   progressMs: number;
   durationMs: number;
+  isPlaying: boolean;
 }
 
 function formatTime(ms: number): string {
@@ -12,17 +14,34 @@ function formatTime(ms: number): string {
   return `${minutes}:${seconds.toString().padStart(2, '0')}`;
 }
 
-export default function ProgressBar({ progressMs, durationMs }: ProgressBarProps) {
-  const percent = durationMs > 0 ? (progressMs / durationMs) * 100 : 0;
+export default function ProgressBar({ progressMs, durationMs, isPlaying }: ProgressBarProps) {
+  const [localProgress, setLocalProgress] = useState(progressMs);
+  const lastSyncRef = useRef(Date.now());
+
+  // Sync with server value when it changes
+  useEffect(() => {
+    setLocalProgress(progressMs);
+    lastSyncRef.current = Date.now();
+  }, [progressMs]);
+
+  // Tick every second when playing
+  useEffect(() => {
+    if (!isPlaying) return;
+
+    const interval = setInterval(() => {
+      setLocalProgress((prev) => Math.min(prev + 1000, durationMs));
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [isPlaying, durationMs]);
+
+  const percent = durationMs > 0 ? (localProgress / durationMs) * 100 : 0;
 
   return (
     <div className="progress-bar">
-      <span className="progress-bar__time">{formatTime(progressMs)}</span>
+      <span className="progress-bar__time">{formatTime(localProgress)}</span>
       <div className="progress-bar__track">
-        <div
-          className="progress-bar__fill"
-          style={{ width: `${percent}%` }}
-        />
+        <div className="progress-bar__fill" style={{ width: `${percent}%` }} />
       </div>
       <span className="progress-bar__time">{formatTime(durationMs)}</span>
     </div>

--- a/packages/client/src/components/SongCard.css
+++ b/packages/client/src/components/SongCard.css
@@ -16,7 +16,9 @@
   border: 2px solid rgba(252, 252, 252, 0.95);
   background-size: cover;
   background-position: center;
-  transition: background-image 1s ease-in 1s;
+  transition:
+    background-image 1s ease-in 1s,
+    box-shadow 3s ease-in-out;
   box-shadow:
     0 3px 5px -1px rgba(0, 0, 0, 0.2),
     0 6px 10px 0 rgba(0, 0, 0, 0.14),

--- a/packages/client/src/components/SongCard.css
+++ b/packages/client/src/components/SongCard.css
@@ -36,34 +36,29 @@
 .song-card__details {
   display: flex;
   flex-direction: column;
-  width: 300px;
+  max-width: 350px;
 }
 
 .song-card__text {
   color: rgba(255, 255, 255, 0.87);
-  max-width: 100%;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   text-shadow: 2px 2px 7px rgba(94, 94, 94, 0.44);
   padding: 0;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .song-card__artist {
-  font-size: 1.5em;
+  font-size: clamp(1em, 3vw, 1.5em);
   font-weight: bold;
-  animation: fadein 2s;
 }
 
 .song-card__album {
-  font-size: 1.2em;
-  animation: fadein 2s;
+  font-size: clamp(0.85em, 2.5vw, 1.2em);
 }
 
 .song-card__title {
-  font-size: 1.2em;
-  margin-top: 1.2em;
-  animation: fadein 2s;
+  font-size: clamp(0.85em, 2.5vw, 1.2em);
+  margin-top: 0.8em;
 }
 
 @media (max-width: 600px) {

--- a/packages/client/src/components/SongCard.css
+++ b/packages/client/src/components/SongCard.css
@@ -6,7 +6,15 @@
   left: 30px;
   bottom: 30px;
   z-index: 100;
-  animation: fadein 1s;
+  transition: opacity 0.5s ease-in-out;
+}
+
+.song-card--visible {
+  opacity: 1;
+}
+
+.song-card--hidden {
+  opacity: 0;
 }
 
 .song-card__cover {
@@ -56,4 +64,30 @@
   font-size: 1.2em;
   margin-top: 1.2em;
   animation: fadein 2s;
+}
+
+@media (max-width: 600px) {
+  .song-card {
+    left: 15px;
+    bottom: 15px;
+  }
+
+  .song-card__cover {
+    width: 80px;
+    height: 80px;
+    margin-right: 12px;
+  }
+
+  .song-card__details {
+    width: 200px;
+  }
+
+  .song-card__artist {
+    font-size: 1.1em;
+  }
+
+  .song-card__album,
+  .song-card__title {
+    font-size: 0.9em;
+  }
 }

--- a/packages/client/src/components/SongCard.tsx
+++ b/packages/client/src/components/SongCard.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import './SongCard.css';
 
 interface SongCardProps {
@@ -6,6 +7,7 @@ interface SongCardProps {
   albumName: string;
   albumImageUrl: string | undefined;
   dominantColor?: string | null;
+  songId: string;
 }
 
 export default function SongCard({
@@ -14,21 +16,50 @@ export default function SongCard({
   albumName,
   albumImageUrl,
   dominantColor,
+  songId,
 }: SongCardProps) {
+  const [visible, setVisible] = useState(true);
+  const [displayedSong, setDisplayedSong] = useState({
+    artistName,
+    songTitle,
+    albumName,
+    albumImageUrl,
+    songId,
+  });
+
+  useEffect(() => {
+    if (songId === displayedSong.songId) return;
+
+    // Fade out
+    setVisible(false);
+
+    // After fade-out, update content and fade in
+    const timer = setTimeout(() => {
+      setDisplayedSong({ artistName, songTitle, albumName, albumImageUrl, songId });
+      setVisible(true);
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [songId, artistName, songTitle, albumName, albumImageUrl, displayedSong.songId]);
+
   const coverStyle = {
-    backgroundImage: `url("${albumImageUrl}")`,
+    backgroundImage: `url("${displayedSong.albumImageUrl}")`,
     boxShadow: dominantColor
       ? `0 0 40px 10px ${dominantColor}, 0 6px 10px 0 rgba(0,0,0,.14)`
       : undefined,
   };
 
   return (
-    <div className="song-card">
-      <div className="song-card__cover" style={coverStyle} title={albumName} />
+    <div className={`song-card ${visible ? 'song-card--visible' : 'song-card--hidden'}`}>
+      <div className="song-card__cover" style={coverStyle} title={displayedSong.albumName} />
       <div className="song-card__details">
-        <div className="song-card__text song-card__artist">{artistName.toUpperCase()}</div>
-        <div className="song-card__text song-card__album">{albumName.toUpperCase()}</div>
-        <div className="song-card__text song-card__title">{songTitle}</div>
+        <div className="song-card__text song-card__artist">
+          {displayedSong.artistName.toUpperCase()}
+        </div>
+        <div className="song-card__text song-card__album">
+          {displayedSong.albumName.toUpperCase()}
+        </div>
+        <div className="song-card__text song-card__title">{displayedSong.songTitle}</div>
       </div>
     </div>
   );

--- a/packages/client/src/components/SongCard.tsx
+++ b/packages/client/src/components/SongCard.tsx
@@ -5,6 +5,7 @@ interface SongCardProps {
   songTitle: string;
   albumName: string;
   albumImageUrl: string | undefined;
+  dominantColor?: string | null;
 }
 
 export default function SongCard({
@@ -12,14 +13,18 @@ export default function SongCard({
   songTitle,
   albumName,
   albumImageUrl,
+  dominantColor,
 }: SongCardProps) {
+  const coverStyle = {
+    backgroundImage: `url("${albumImageUrl}")`,
+    boxShadow: dominantColor
+      ? `0 0 40px 10px ${dominantColor}, 0 6px 10px 0 rgba(0,0,0,.14)`
+      : undefined,
+  };
+
   return (
     <div className="song-card">
-      <div
-        className="song-card__cover"
-        style={{ backgroundImage: `url("${albumImageUrl}")` }}
-        title={albumName}
-      />
+      <div className="song-card__cover" style={coverStyle} title={albumName} />
       <div className="song-card__details">
         <div className="song-card__text song-card__artist">{artistName.toUpperCase()}</div>
         <div className="song-card__text song-card__album">{albumName.toUpperCase()}</div>

--- a/packages/client/src/components/SongCard.tsx
+++ b/packages/client/src/components/SongCard.tsx
@@ -45,7 +45,7 @@ export default function SongCard({
   const coverStyle = {
     backgroundImage: `url("${displayedSong.albumImageUrl}")`,
     boxShadow: dominantColor
-      ? `0 0 40px 10px ${dominantColor}, 0 6px 10px 0 rgba(0,0,0,.14)`
+      ? `0 0 4px 1px ${dominantColor}, 0 6px 10px 0 rgba(0,0,0,.14)`
       : undefined,
   };
 

--- a/packages/client/src/components/UserMenu.css
+++ b/packages/client/src/components/UserMenu.css
@@ -4,14 +4,25 @@
   position: relative;
 }
 
-.user-menu__icon {
+.user-menu__trigger {
+  background: none;
+  border: none;
   margin-left: 8px;
   padding: 8px;
-  color: rgba(255, 255, 255, 0.87);
   cursor: pointer;
 }
 
-.user-menu__icon:hover {
+.user-menu__trigger:focus-visible {
+  outline: 2px solid #1db954;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.user-menu__icon {
+  color: rgba(255, 255, 255, 0.87);
+}
+
+.user-menu__trigger:hover .user-menu__icon {
   color: rgba(255, 255, 255, 0.54);
 }
 

--- a/packages/client/src/components/UserMenu.tsx
+++ b/packages/client/src/components/UserMenu.tsx
@@ -21,16 +21,13 @@ export default function UserMenu({ onLogout }: UserMenuProps) {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false);
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        setOpen((o) => !o);
-      }
-    },
-    [],
-  );
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') setOpen(false);
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      setOpen((o) => !o);
+    }
+  }, []);
 
   return (
     <div className="user-menu" ref={menuRef}>

--- a/packages/client/src/components/UserMenu.tsx
+++ b/packages/client/src/components/UserMenu.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCaretDown } from '@fortawesome/free-solid-svg-icons';
 import './UserMenu.css';
@@ -21,17 +21,32 @@ export default function UserMenu({ onLogout }: UserMenuProps) {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        setOpen((o) => !o);
+      }
+    },
+    [],
+  );
+
   return (
     <div className="user-menu" ref={menuRef}>
-      <FontAwesomeIcon
-        icon={faCaretDown}
-        className="user-menu__icon"
-        title="Menu"
+      <button
+        className="user-menu__trigger"
         onClick={() => setOpen(!open)}
-      />
+        onKeyDown={handleKeyDown}
+        aria-label="User menu"
+        aria-expanded={open}
+        aria-haspopup="true"
+      >
+        <FontAwesomeIcon icon={faCaretDown} className="user-menu__icon" />
+      </button>
       {open && (
-        <div className="user-menu__dropdown">
-          <button className="user-menu__item" onClick={onLogout}>
+        <div className="user-menu__dropdown" role="menu">
+          <button className="user-menu__item" role="menuitem" onClick={onLogout}>
             Log Out
           </button>
         </div>

--- a/packages/client/src/components/__tests__/AlbumGrid.test.tsx
+++ b/packages/client/src/components/__tests__/AlbumGrid.test.tsx
@@ -9,14 +9,15 @@ const mockTiles: Album[] = [
 ];
 
 describe('AlbumGrid', () => {
-  it('renders images for each tile', () => {
+  it('renders a tile for each album', () => {
     const { container } = render(
       <AlbumGrid tiles={mockTiles} gridCols={6} gridRows={6} base={120} />,
     );
-    const images = container.querySelectorAll('img');
-    expect(images).toHaveLength(2);
-    expect(images[0]).toHaveAttribute('alt', 'Album 1');
-    expect(images[1]).toHaveAttribute('alt', 'Album 2');
+    const tiles = container.querySelectorAll('.album-grid__tile');
+    expect(tiles).toHaveLength(2);
+    // Each FlippableTile has front and back faces with images
+    const images = container.querySelectorAll('img[alt="Album 1"]');
+    expect(images.length).toBeGreaterThanOrEqual(1);
   });
 
   it('returns null when tiles is empty', () => {

--- a/packages/client/src/contexts/SpotifyContext.tsx
+++ b/packages/client/src/contexts/SpotifyContext.tsx
@@ -23,6 +23,7 @@ type SpotifyAction =
   | { type: 'FETCH_NOW_PLAYING_REQUEST' }
   | { type: 'FETCH_NOW_PLAYING_SUCCESS'; payload: NowPlaying }
   | { type: 'FETCH_NOW_PLAYING_DUPE' }
+  | { type: 'UPDATE_PROGRESS'; payload: { progressMs: number; isPlaying: boolean } }
   | { type: 'FETCH_NOW_PLAYING_FAILURE'; payload: unknown }
   | { type: 'CLEAR_RELATED_ALBUMS' }
   | { type: 'FETCH_RELATED_ALBUMS_REQUEST' }
@@ -73,6 +74,17 @@ function reducer(state: SpotifyState, action: SpotifyAction): SpotifyState {
 
     case 'FETCH_NOW_PLAYING_DUPE':
       return { ...state, initialized: true, loading: false };
+
+    case 'UPDATE_PROGRESS':
+      if (!state.nowPlaying) return state;
+      return {
+        ...state,
+        nowPlaying: {
+          ...state.nowPlaying,
+          progressMs: action.payload.progressMs,
+          isPlaying: action.payload.isPlaying,
+        },
+      };
 
     case 'FETCH_NOW_PLAYING_FAILURE':
       return { ...state, initialized: true, loading: false, error: action.payload };
@@ -136,6 +148,13 @@ export function SpotifyProvider({ children }: SpotifyProviderProps) {
 
         if (item.id === currentSongId) {
           dispatch({ type: 'FETCH_NOW_PLAYING_DUPE' });
+          dispatch({
+            type: 'UPDATE_PROGRESS',
+            payload: {
+              progressMs: data.progress_ms ?? 0,
+              isPlaying: data.is_playing ?? false,
+            },
+          });
           return { songId: item.id, albumId: item.album?.id };
         }
 
@@ -149,6 +168,9 @@ export function SpotifyProvider({ children }: SpotifyProviderProps) {
           albumImageUrl: item.album.images[0]?.url,
           albumArtists: item.album.artists,
           albumImages: item.album.images,
+          progressMs: data.progress_ms ?? 0,
+          durationMs: item.duration_ms ?? 0,
+          isPlaying: data.is_playing ?? false,
         };
 
         dispatch({ type: 'FETCH_NOW_PLAYING_SUCCESS', payload: info });

--- a/packages/client/src/contexts/UserContext.tsx
+++ b/packages/client/src/contexts/UserContext.tsx
@@ -37,8 +37,7 @@ export function UserProvider({ children }: UserProviderProps) {
       })
       .catch((err: { response?: { data?: unknown }; message?: string }) => {
         const data = err.response?.data;
-        const message =
-          typeof data === 'string' ? data : err.message || 'Unknown error';
+        const message = typeof data === 'string' ? data : err.message || 'Unknown error';
         setError(message);
         setLoading(false);
       });

--- a/packages/client/src/contexts/UserContext.tsx
+++ b/packages/client/src/contexts/UserContext.tsx
@@ -35,8 +35,11 @@ export function UserProvider({ children }: UserProviderProps) {
         setUser(profile);
         setLoading(false);
       })
-      .catch((err: { response?: { data?: string }; message?: string }) => {
-        setError(err.response?.data || err.message || 'Unknown error');
+      .catch((err: { response?: { data?: unknown }; message?: string }) => {
+        const data = err.response?.data;
+        const message =
+          typeof data === 'string' ? data : err.message || 'Unknown error';
+        setError(message);
         setLoading(false);
       });
   }, []);

--- a/packages/client/src/hooks/useAlbumGrid.ts
+++ b/packages/client/src/hooks/useAlbumGrid.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import type { RelatedAlbums, WindowSize, Album, AlbumGridResult } from '../types';
 
-const BASE = 120;
+const BASE = 100;
 
 interface TemplateSlot {
   col: number;
@@ -9,32 +9,80 @@ interface TemplateSlot {
   span: number;
 }
 
-// Fixed 6x6 tile template -- guaranteed gap-free because every cell is
-// explicitly assigned. Mix of 2x2 large tiles and 1x1 small tiles.
-// This pattern tiles seamlessly when repeated horizontally and vertically.
-const TEMPLATE: TemplateSlot[] = [
-  // { col, row, span } -- all tiles are square (span x span)
-  { col: 0, row: 0, span: 2 },
-  { col: 2, row: 0, span: 1 },
+// Three alternating 6x6 templates with 1x1, 2x2, and 3x3 tiles.
+// Each template covers every cell in the 6x6 grid with no gaps.
+// Templates alternate in a checkerboard pattern to reduce visual repetition.
+
+// Template A: 3x3 in top-left, 2x2 scattered
+const TEMPLATE_A: TemplateSlot[] = [
+  { col: 0, row: 0, span: 3 },
   { col: 3, row: 0, span: 2 },
   { col: 5, row: 0, span: 1 },
-  { col: 2, row: 1, span: 1 },
   { col: 5, row: 1, span: 1 },
-  { col: 0, row: 2, span: 1 },
-  { col: 1, row: 2, span: 2 },
   { col: 3, row: 2, span: 1 },
   { col: 4, row: 2, span: 2 },
-  { col: 0, row: 3, span: 1 },
-  { col: 3, row: 3, span: 1 },
-  { col: 0, row: 4, span: 2 },
-  { col: 2, row: 4, span: 1 },
-  { col: 3, row: 4, span: 1 },
+  { col: 0, row: 3, span: 2 },
+  { col: 2, row: 3, span: 2 },
+  { col: 4, row: 3, span: 1 },
+  { col: 5, row: 3, span: 1 },
+  { col: 0, row: 4, span: 1 },
+  { col: 1, row: 4, span: 1 },
+  { col: 2, row: 4, span: 2 },
   { col: 4, row: 4, span: 2 },
+  { col: 0, row: 5, span: 2 },
   { col: 2, row: 5, span: 1 },
   { col: 3, row: 5, span: 1 },
 ];
-const TEMPLATE_COLS = 6;
-const TEMPLATE_ROWS = 6;
+
+// Template B: 3x3 in bottom-right
+const TEMPLATE_B: TemplateSlot[] = [
+  { col: 0, row: 0, span: 2 },
+  { col: 2, row: 0, span: 1 },
+  { col: 3, row: 0, span: 1 },
+  { col: 4, row: 0, span: 2 },
+  { col: 2, row: 1, span: 2 },
+  { col: 0, row: 2, span: 1 },
+  { col: 1, row: 2, span: 1 },
+  { col: 2, row: 2, span: 1 },
+  { col: 4, row: 2, span: 1 },
+  { col: 5, row: 2, span: 1 },
+  { col: 0, row: 3, span: 2 },
+  { col: 2, row: 3, span: 1 },
+  { col: 3, row: 3, span: 3 },
+  { col: 0, row: 4, span: 1 },
+  { col: 1, row: 4, span: 2 },
+  { col: 0, row: 5, span: 1 },
+  { col: 1, row: 5, span: 1 },
+  { col: 2, row: 5, span: 1 },
+];
+
+// Template C: 3x3 offset center, small tiles on edges
+const TEMPLATE_C: TemplateSlot[] = [
+  { col: 0, row: 0, span: 1 },
+  { col: 1, row: 0, span: 2 },
+  { col: 3, row: 0, span: 1 },
+  { col: 4, row: 0, span: 2 },
+  { col: 0, row: 1, span: 1 },
+  { col: 3, row: 1, span: 1 },
+  { col: 0, row: 2, span: 2 },
+  { col: 2, row: 2, span: 1 },
+  { col: 3, row: 2, span: 3 },
+  { col: 2, row: 3, span: 1 },
+  { col: 0, row: 3, span: 1 },
+  { col: 1, row: 3, span: 1 },
+  { col: 0, row: 4, span: 2 },
+  { col: 2, row: 4, span: 2 },
+  { col: 4, row: 4, span: 1 },
+  { col: 5, row: 4, span: 1 },
+  { col: 4, row: 5, span: 2 },
+  { col: 0, row: 5, span: 1 },
+  { col: 1, row: 5, span: 1 },
+  { col: 2, row: 5, span: 1 },
+  { col: 3, row: 5, span: 1 },
+];
+
+const TEMPLATES = [TEMPLATE_A, TEMPLATE_B, TEMPLATE_C];
+const TEMPLATE_SIZE = 6;
 
 export default function useAlbumGrid(
   relatedAlbums: RelatedAlbums,
@@ -48,22 +96,22 @@ export default function useAlbumGrid(
       return { tiles: [], gridCols: 0, gridRows: 0, base: BASE };
     }
 
-    // How many template repetitions to fill ~1.5x viewport in each direction
-    // (extra for animation headroom)
-    const blockWidth = TEMPLATE_COLS * BASE;
-    const blockHeight = TEMPLATE_ROWS * BASE;
-    const repsX = Math.ceil((width * 1.5) / blockWidth) + 1;
-    const repsY = Math.ceil((height * 1.5) / blockHeight) + 1;
+    const blockSize = TEMPLATE_SIZE * BASE;
+    const repsX = Math.ceil((width * 1.6) / blockSize) + 1;
+    const repsY = Math.ceil((height * 1.6) / blockSize) + 1;
 
     let albumCursor = 0;
     const tiles: Album[] = [];
 
     for (let ry = 0; ry < repsY; ry++) {
       for (let rx = 0; rx < repsX; rx++) {
-        const offsetX = rx * TEMPLATE_COLS;
-        const offsetY = ry * TEMPLATE_ROWS;
+        const offsetX = rx * TEMPLATE_SIZE;
+        const offsetY = ry * TEMPLATE_SIZE;
+        // Alternate templates in a checkerboard pattern
+        const templateIndex = (rx + ry) % TEMPLATES.length;
+        const template = TEMPLATES[templateIndex];
 
-        for (const slot of TEMPLATE) {
+        for (const slot of template) {
           const id = allAlbumIds[albumCursor % allAlbumIds.length];
           const album = byAlbumId[id];
           albumCursor++;
@@ -82,8 +130,8 @@ export default function useAlbumGrid(
 
     return {
       tiles,
-      gridCols: repsX * TEMPLATE_COLS,
-      gridRows: repsY * TEMPLATE_ROWS,
+      gridCols: repsX * TEMPLATE_SIZE,
+      gridRows: repsY * TEMPLATE_SIZE,
       base: BASE,
     };
   }, [relatedAlbums, windowSize]);

--- a/packages/client/src/hooks/useAlbumGrid.ts
+++ b/packages/client/src/hooks/useAlbumGrid.ts
@@ -117,7 +117,7 @@ export default function useAlbumGrid(
           albumCursor++;
 
           tiles.push({
-            id: `${album.id}_${rx}_${ry}_${slot.col}_${slot.row}`,
+            id: `tile_${rx}_${ry}_${slot.col}_${slot.row}`,
             title: album.name,
             imageUrl: (album.images[1] || album.images[0])?.url,
             col: offsetX + slot.col + 1,

--- a/packages/client/src/hooks/useDominantColor.ts
+++ b/packages/client/src/hooks/useDominantColor.ts
@@ -1,0 +1,61 @@
+import { useState, useEffect } from 'react';
+
+function extractDominantColor(img: HTMLImageElement): string | null {
+  try {
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return null;
+
+    // Sample at a small size for performance
+    canvas.width = 10;
+    canvas.height = 10;
+    ctx.drawImage(img, 0, 0, 10, 10);
+
+    const data = ctx.getImageData(0, 0, 10, 10).data;
+
+    // Average all pixel colors
+    let r = 0,
+      g = 0,
+      b = 0;
+    const pixelCount = data.length / 4;
+    for (let i = 0; i < data.length; i += 4) {
+      r += data[i];
+      g += data[i + 1];
+      b += data[i + 2];
+    }
+
+    r = Math.round(r / pixelCount);
+    g = Math.round(g / pixelCount);
+    b = Math.round(b / pixelCount);
+
+    return `rgb(${r}, ${g}, ${b})`;
+  } catch {
+    return null;
+  }
+}
+
+export default function useDominantColor(imageUrl: string | undefined): string | null {
+  const [color, setColor] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!imageUrl) {
+      setColor(null);
+      return;
+    }
+
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.src = imageUrl;
+
+    const onLoad = () => setColor(extractDominantColor(img));
+
+    if (img.complete) {
+      onLoad();
+    } else {
+      img.addEventListener('load', onLoad);
+      return () => img.removeEventListener('load', onLoad);
+    }
+  }, [imageUrl]);
+
+  return color;
+}

--- a/packages/client/src/hooks/useNowPlayingPoller.ts
+++ b/packages/client/src/hooks/useNowPlayingPoller.ts
@@ -4,7 +4,7 @@ import { useSpotify } from '../contexts/SpotifyContext';
 const POLL_INTERVAL = 3000;
 
 export default function useNowPlayingPoller(): void {
-  const { fetchNowPlaying, fetchRelatedAlbums, clearRelatedAlbums } = useSpotify();
+  const { fetchNowPlaying, fetchRelatedAlbums } = useSpotify();
 
   const loadingRef = useRef<boolean>(false);
   const currentAlbumIdRef = useRef<string | null>(null);
@@ -19,7 +19,8 @@ export default function useNowPlayingPoller(): void {
 
       if (currentAlbumIdRef.current !== info.albumId) {
         currentAlbumIdRef.current = info.albumId;
-        clearRelatedAlbums();
+        // Stale-while-revalidate: keep old albums visible while new ones load.
+        // FETCH_RELATED_ALBUMS_SUCCESS replaces the state entirely.
         fetchRelatedAlbums(info.songId);
       }
     };
@@ -27,5 +28,5 @@ export default function useNowPlayingPoller(): void {
     poll();
     const id = setInterval(poll, POLL_INTERVAL);
     return () => clearInterval(id);
-  }, [fetchNowPlaying, fetchRelatedAlbums, clearRelatedAlbums]);
+  }, [fetchNowPlaying, fetchRelatedAlbums]);
 }

--- a/packages/client/src/pages/VisualizationContent.css
+++ b/packages/client/src/pages/VisualizationContent.css
@@ -99,6 +99,17 @@
   animation: pulse-gradient 4s ease-in-out infinite alternate;
 }
 
+@media (max-width: 600px) {
+  .visualization__github-icon {
+    display: none;
+  }
+
+  .visualization__user-container {
+    top: 15px;
+    right: 15px;
+  }
+}
+
 @keyframes pulse-gradient {
   0% {
     height: 150px;

--- a/packages/client/src/pages/VisualizationContent.css
+++ b/packages/client/src/pages/VisualizationContent.css
@@ -49,6 +49,38 @@
   z-index: 100;
 }
 
+.visualization__error {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  justify-content: center;
+  align-items: center;
+  z-index: 100;
+  gap: 16px;
+}
+
+.visualization__error p {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.visualization__reconnect-btn {
+  padding: 10px 24px;
+  background-color: #1db954;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-family: 'Source Sans Pro', sans-serif;
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.visualization__reconnect-btn:hover {
+  background-color: #1ed760;
+}
+
 .visualization__bottom-gradient {
   position: absolute;
   bottom: 0;

--- a/packages/client/src/pages/VisualizationContent.tsx
+++ b/packages/client/src/pages/VisualizationContent.tsx
@@ -19,8 +19,8 @@ const REPO_URL = 'https://github.com/cdtinney/spune';
 
 export default function VisualizationContent() {
   useNowPlayingPoller();
-  const { user, logout } = useUser();
-  const { nowPlaying, relatedAlbums, initialized } = useSpotify();
+  const { user, logout, login } = useUser();
+  const { nowPlaying, relatedAlbums, initialized, error } = useSpotify();
   const windowSize = useWindowSize();
   const { tiles, gridCols, gridRows, base } = useAlbumGrid(relatedAlbums, windowSize);
   const [fullscreen, setFullscreen] = useState<boolean>(false);
@@ -46,6 +46,7 @@ export default function VisualizationContent() {
   const userImageUrl = typeof photo === 'string' ? photo : photo?.url || photo?.value;
   const isInitialLoad = !initialized;
   const songPlaying = nowPlaying?.artistName && nowPlaying?.songTitle;
+  const hasError = !!error;
 
   return (
     <div className="visualization">
@@ -82,7 +83,16 @@ export default function VisualizationContent() {
       <div className="visualization__content">
         {isInitialLoad && <LoadingScreen className="visualization__loading" />}
 
-        {!isInitialLoad && !songPlaying && (
+        {!isInitialLoad && hasError && !songPlaying && (
+          <div className="visualization__error">
+            <p>Session expired or connection failed.</p>
+            <button className="visualization__reconnect-btn" onClick={login}>
+              Reconnect with Spotify
+            </button>
+          </div>
+        )}
+
+        {!isInitialLoad && !hasError && !songPlaying && (
           <div className="visualization__empty">
             <p>No song playing. Play something.</p>
           </div>

--- a/packages/client/src/pages/VisualizationContent.tsx
+++ b/packages/client/src/pages/VisualizationContent.tsx
@@ -112,6 +112,7 @@ export default function VisualizationContent() {
         <ProgressBar
           progressMs={nowPlaying.progressMs}
           durationMs={nowPlaying.durationMs}
+          isPlaying={nowPlaying.isPlaying}
         />
       )}
 

--- a/packages/client/src/pages/VisualizationContent.tsx
+++ b/packages/client/src/pages/VisualizationContent.tsx
@@ -14,6 +14,7 @@ import AlbumGrid from '../components/AlbumGrid';
 import UserAvatar from '../components/UserAvatar';
 import UserMenu from '../components/UserMenu';
 import FullscreenButton from '../components/FullscreenButton';
+import ProgressBar from '../components/ProgressBar';
 import './VisualizationContent.css';
 
 const REPO_URL = 'https://github.com/cdtinney/spune';
@@ -106,6 +107,13 @@ export default function VisualizationContent() {
           <AlbumGrid tiles={tiles} gridCols={gridCols} gridRows={gridRows} base={base} />
         )}
       </div>
+
+      {!isInitialLoad && songPlaying && (
+        <ProgressBar
+          progressMs={nowPlaying.progressMs}
+          durationMs={nowPlaying.durationMs}
+        />
+      )}
 
       <div className="visualization__bottom-gradient" />
     </div>

--- a/packages/client/src/pages/VisualizationContent.tsx
+++ b/packages/client/src/pages/VisualizationContent.tsx
@@ -6,6 +6,7 @@ import { useSpotify } from '../contexts/SpotifyContext';
 import useNowPlayingPoller from '../hooks/useNowPlayingPoller';
 import useWindowSize from '../hooks/useWindowSize';
 import useAlbumGrid from '../hooks/useAlbumGrid';
+import useDominantColor from '../hooks/useDominantColor';
 import LoadingScreen from '../components/LoadingScreen';
 import CoverOverlay from '../components/CoverOverlay';
 import SongCard from '../components/SongCard';
@@ -23,6 +24,7 @@ export default function VisualizationContent() {
   const { nowPlaying, relatedAlbums, initialized, error } = useSpotify();
   const windowSize = useWindowSize();
   const { tiles, gridCols, gridRows, base } = useAlbumGrid(relatedAlbums, windowSize);
+  const dominantColor = useDominantColor(nowPlaying?.albumImageUrl);
   const [fullscreen, setFullscreen] = useState<boolean>(false);
 
   useEffect(() => {
@@ -52,7 +54,7 @@ export default function VisualizationContent() {
     <div className="visualization">
       {!isInitialLoad && <FullscreenButton onClick={handleFullscreenToggle} />}
 
-      <CoverOverlay />
+      <CoverOverlay dominantColor={dominantColor} />
 
       {!isInitialLoad && (
         <>
@@ -77,6 +79,7 @@ export default function VisualizationContent() {
           songTitle={nowPlaying.songTitle}
           albumName={nowPlaying.albumName}
           albumImageUrl={nowPlaying.albumImageUrl}
+          dominantColor={dominantColor}
         />
       )}
 

--- a/packages/client/src/pages/VisualizationContent.tsx
+++ b/packages/client/src/pages/VisualizationContent.tsx
@@ -75,6 +75,7 @@ export default function VisualizationContent() {
 
       {!isInitialLoad && songPlaying && (
         <SongCard
+          songId={nowPlaying.songId}
           artistName={nowPlaying.artistName}
           songTitle={nowPlaying.songTitle}
           albumName={nowPlaying.albumName}

--- a/packages/client/src/types/spotify.ts
+++ b/packages/client/src/types/spotify.ts
@@ -27,6 +27,7 @@ export interface SpotifyTrack {
   name: string;
   artists: SpotifyArtist[];
   album: SpotifyAlbum;
+  duration_ms?: number;
   uri?: string;
   href?: string;
 }
@@ -47,6 +48,9 @@ export interface NowPlaying {
   albumImageUrl: string | undefined;
   albumArtists: SpotifyArtist[];
   albumImages: SpotifyImage[];
+  progressMs: number;
+  durationMs: number;
+  isPlaying: boolean;
 }
 
 export interface RelatedAlbums {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -32,6 +32,7 @@
     "express": "^4.22.1",
     "express-rate-limit": "^8.3.2",
     "express-session": "^1.19.0",
+    "lru-cache": "^11.3.5",
     "passport": "^0.7.0",
     "passport-oauth2-refresh": "^2.2.0",
     "passport-spotify": "^1.0.1",

--- a/packages/server/src/cache/__tests__/index.test.ts
+++ b/packages/server/src/cache/__tests__/index.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  relatedArtistsCache,
+  artistIdCache,
+  artistAlbumsCache,
+  normalizeKey,
+  NOT_FOUND,
+} from '../index';
+
+describe('cache module', () => {
+  afterEach(() => {
+    relatedArtistsCache.clear();
+    artistIdCache.clear();
+    artistAlbumsCache.clear();
+  });
+
+  describe('normalizeKey()', () => {
+    it('lowercases and trims the input', () => {
+      expect(normalizeKey('  Foo Bar  ')).toBe('foo bar');
+    });
+  });
+
+  describe('relatedArtistsCache', () => {
+    it('stores and retrieves values', () => {
+      relatedArtistsCache.set('key', ['Artist A']);
+      expect(relatedArtistsCache.get('key')).toEqual(['Artist A']);
+    });
+
+    it('returns undefined for missing keys', () => {
+      expect(relatedArtistsCache.get('missing')).toBeUndefined();
+    });
+  });
+
+  describe('artistIdCache', () => {
+    it('stores and retrieves string values', () => {
+      artistIdCache.set('known', 'spotify-id-123');
+      expect(artistIdCache.get('known')).toBe('spotify-id-123');
+    });
+
+    it('stores NOT_FOUND sentinel for unresolved artists', () => {
+      artistIdCache.set('unknown', NOT_FOUND);
+      expect(artistIdCache.get('unknown')).toBe(NOT_FOUND);
+    });
+  });
+
+  describe('artistAlbumsCache', () => {
+    it('stores and retrieves album results', () => {
+      const result = {
+        artistId: 'abc',
+        albums: [{ name: 'Album 1' }],
+      };
+      artistAlbumsCache.set('abc', result as any);
+      expect(artistAlbumsCache.get('abc')).toEqual(result);
+    });
+  });
+});

--- a/packages/server/src/cache/index.ts
+++ b/packages/server/src/cache/index.ts
@@ -1,0 +1,32 @@
+import { LRUCache } from 'lru-cache';
+import type { ArtistAlbumsResult } from '../types';
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
+const THIRTY_MIN_MS = 30 * 60 * 1000;
+
+/** Sentinel value representing a cached "not found" result. */
+export const NOT_FOUND = Symbol('NOT_FOUND');
+
+export type ArtistIdCacheValue = string | typeof NOT_FOUND;
+
+/** Related artist names by primary artist name (case-insensitive key). */
+export const relatedArtistsCache = new LRUCache<string, string[]>({
+  max: 200,
+  ttl: ONE_HOUR_MS,
+});
+
+/** Spotify artist ID by artist name (case-insensitive key). Uses NOT_FOUND for null results. */
+export const artistIdCache = new LRUCache<string, ArtistIdCacheValue>({
+  max: 500,
+  ttl: ONE_HOUR_MS,
+});
+
+/** Artist albums by Spotify artist ID. */
+export const artistAlbumsCache = new LRUCache<string, ArtistAlbumsResult>({
+  max: 500,
+  ttl: THIRTY_MIN_MS,
+});
+
+export function normalizeKey(name: string): string {
+  return String(name).toLowerCase().trim();
+}

--- a/packages/server/src/middleware/rateLimiter.ts
+++ b/packages/server/src/middleware/rateLimiter.ts
@@ -1,31 +1,36 @@
-import rateLimit, { type RateLimitRequestHandler } from 'express-rate-limit';
+import rateLimit from 'express-rate-limit';
+import type { RequestHandler } from 'express';
 
 const isProduction = process.env.NODE_ENV === 'production';
 
-// General API rate limit: 1000 requests per 15 minutes per IP.
-export const apiLimiter: RateLimitRequestHandler = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: isProduction ? 1000 : 0, // 0 = disabled in dev
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: 'Too many requests, please try again later.',
-});
+const passthrough: RequestHandler = (_req, _res, next) => next();
 
-// Auth routes: 50 requests per 15 minutes per IP.
-export const authLimiter: RateLimitRequestHandler = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: isProduction ? 50 : 0,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: 'Too many authentication requests, please try again later.',
-});
+export const apiLimiter: RequestHandler = isProduction
+  ? rateLimit({
+      windowMs: 15 * 60 * 1000,
+      max: 1000,
+      standardHeaders: true,
+      legacyHeaders: false,
+      message: 'Too many requests, please try again later.',
+    })
+  : passthrough;
 
-// Spotify API proxy routes: 500 requests per 15 minutes per IP.
-// Higher limit since the client polls every 3 seconds (~300 requests/15min).
-export const spotifyLimiter: RateLimitRequestHandler = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: isProduction ? 500 : 0,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: 'Too many requests, please try again later.',
-});
+export const authLimiter: RequestHandler = isProduction
+  ? rateLimit({
+      windowMs: 15 * 60 * 1000,
+      max: 50,
+      standardHeaders: true,
+      legacyHeaders: false,
+      message: 'Too many authentication requests, please try again later.',
+    })
+  : passthrough;
+
+export const spotifyLimiter: RequestHandler = isProduction
+  ? rateLimit({
+      windowMs: 15 * 60 * 1000,
+      max: 500,
+      standardHeaders: true,
+      legacyHeaders: false,
+      message: 'Too many requests, please try again later.',
+    })
+  : passthrough;

--- a/packages/server/src/middleware/rateLimiter.ts
+++ b/packages/server/src/middleware/rateLimiter.ts
@@ -1,29 +1,31 @@
 import rateLimit, { type RateLimitRequestHandler } from 'express-rate-limit';
 
-// General API rate limit: 100 requests per 15 minutes per IP.
+const isProduction = process.env.NODE_ENV === 'production';
+
+// General API rate limit: 1000 requests per 15 minutes per IP.
 export const apiLimiter: RateLimitRequestHandler = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 100,
+  max: isProduction ? 1000 : 0, // 0 = disabled in dev
   standardHeaders: true,
   legacyHeaders: false,
-  message: { error: 'Too many requests, please try again later.' },
+  message: 'Too many requests, please try again later.',
 });
 
-// Stricter limit for auth routes: 20 requests per 15 minutes per IP.
+// Auth routes: 50 requests per 15 minutes per IP.
 export const authLimiter: RateLimitRequestHandler = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 20,
+  max: isProduction ? 50 : 0,
   standardHeaders: true,
   legacyHeaders: false,
-  message: { error: 'Too many authentication requests, please try again later.' },
+  message: 'Too many authentication requests, please try again later.',
 });
 
-// Spotify API proxy routes: 200 requests per 15 minutes per IP.
-// Higher limit since the client polls for playback state.
+// Spotify API proxy routes: 500 requests per 15 minutes per IP.
+// Higher limit since the client polls every 3 seconds (~300 requests/15min).
 export const spotifyLimiter: RateLimitRequestHandler = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 200,
+  max: isProduction ? 500 : 0,
   standardHeaders: true,
   legacyHeaders: false,
-  message: { error: 'Too many requests, please try again later.' },
+  message: 'Too many requests, please try again later.',
 });

--- a/packages/server/src/spotify/api/helpers/__tests__/getArtistAlbums.test.ts
+++ b/packages/server/src/spotify/api/helpers/__tests__/getArtistAlbums.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import getArtistAlbums from '../getArtistAlbums';
+import { artistAlbumsCache } from '../../../../cache';
 
 const mockSpotifyApi = {
   artists: {
@@ -19,6 +20,11 @@ const mockSpotifyApi = {
 };
 
 describe('getArtistAlbums()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    artistAlbumsCache.clear();
+  });
+
   it('returns unique albums for the artist from the api', async () => {
     const result = await getArtistAlbums(mockSpotifyApi, 'fooId');
     expect(result).toEqual({
@@ -29,5 +35,14 @@ describe('getArtistAlbums()', () => {
         },
       ],
     });
+  });
+
+  it('returns cached results on subsequent calls without additional API calls', async () => {
+    const first = await getArtistAlbums(mockSpotifyApi, 'fooId');
+    const callCount = mockSpotifyApi.artists.albums.mock.calls.length;
+
+    const second = await getArtistAlbums(mockSpotifyApi, 'fooId');
+    expect(second).toEqual(first);
+    expect(mockSpotifyApi.artists.albums.mock.calls.length).toBe(callCount);
   });
 });

--- a/packages/server/src/spotify/api/helpers/__tests__/getCurrentlyPlayingRelatedAlbums.test.ts
+++ b/packages/server/src/spotify/api/helpers/__tests__/getCurrentlyPlayingRelatedAlbums.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import getCurrentlyPlayingRelatedAlbums from '../getCurrentlyPlayingRelatedAlbums';
 
 import getRelatedArtists from '../getRelatedArtists';
 import getArtistAlbums from '../getArtistAlbums';
+import { artistIdCache } from '../../../../cache';
 
 vi.mock('../getRelatedArtists');
 vi.mock('../getArtistAlbums');
@@ -14,9 +15,14 @@ const mockSpotifyApi = {
   player: {
     getCurrentlyPlayingTrack: vi.fn(),
   },
+  search: vi.fn(),
 };
 
 describe('getCurrentlyPlayingRelatedAlbums()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    artistIdCache.clear();
+  });
   it('throws an error when the playing track is different than the request track', () => {
     mockSpotifyApi.player.getCurrentlyPlayingTrack.mockImplementation(() =>
       Promise.resolve({

--- a/packages/server/src/spotify/api/helpers/__tests__/getRelatedArtists.test.ts
+++ b/packages/server/src/spotify/api/helpers/__tests__/getRelatedArtists.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import axios from 'axios';
 import getRelatedArtists from '../getRelatedArtists';
+import { relatedArtistsCache } from '../../../../cache';
 
 vi.mock('axios');
 
@@ -9,6 +10,7 @@ const mockedAxios = vi.mocked(axios);
 describe('getRelatedArtists()', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    relatedArtistsCache.clear();
     process.env.LAST_FM_API_KEY = 'test-key';
   });
 
@@ -63,5 +65,31 @@ describe('getRelatedArtists()', () => {
 
     const names = await getRelatedArtists('Test Artist');
     expect(names).toEqual([]);
+  });
+
+  it('returns cached results on subsequent calls without additional API calls', async () => {
+    mockedAxios.get.mockImplementation((url: string) => {
+      if (url.includes('audioscrobbler')) {
+        return Promise.resolve({
+          data: { similarartists: { artist: [{ name: 'Cached Artist' }] } },
+        });
+      }
+      if (url.includes('musicbrainz')) {
+        return Promise.resolve({ data: { artists: [{ id: 'mbid-1' }] } });
+      }
+      if (url.includes('listenbrainz')) {
+        return Promise.resolve({
+          data: { payload: { jspf: { playlist: { track: [] } } } },
+        });
+      }
+      return Promise.reject(new Error('unexpected URL'));
+    });
+
+    const first = await getRelatedArtists('Cache Test');
+    const callCount = mockedAxios.get.mock.calls.length;
+
+    const second = await getRelatedArtists('Cache Test');
+    expect(second).toEqual(first);
+    expect(mockedAxios.get.mock.calls.length).toBe(callCount);
   });
 });

--- a/packages/server/src/spotify/api/helpers/getArtistAlbums.ts
+++ b/packages/server/src/spotify/api/helpers/getArtistAlbums.ts
@@ -1,15 +1,26 @@
 import type { SpotifyApi } from '@spotify/web-api-ts-sdk';
 import uniqueAlbums from '../../utils/uniqueAlbums';
+import logger from '../../../logger';
+import { artistAlbumsCache } from '../../../cache';
 import type { SpotifyAlbum, ArtistAlbumsResult } from '../../../types';
 
 export default async function getArtistAlbums(
   spotifyApi: SpotifyApi,
   artistId: string,
 ): Promise<ArtistAlbumsResult> {
+  const cached = artistAlbumsCache.get(artistId);
+  if (cached) {
+    logger.info(`Artist albums cache hit for ${artistId}`);
+    return cached;
+  }
+
   const data = await spotifyApi.artists.albums(artistId, 'album,compilation', undefined, 50);
 
-  return {
+  const result: ArtistAlbumsResult = {
     artistId,
     albums: uniqueAlbums(data.items as unknown as SpotifyAlbum[]),
   };
+
+  artistAlbumsCache.set(artistId, result);
+  return result;
 }

--- a/packages/server/src/spotify/api/helpers/getCurrentlyPlayingRelatedAlbums.ts
+++ b/packages/server/src/spotify/api/helpers/getCurrentlyPlayingRelatedAlbums.ts
@@ -4,6 +4,7 @@ import getRelatedArtists from './getRelatedArtists';
 import uniqueAlbums from '../../utils/uniqueAlbums';
 import combineTrackArtists from '../../utils/combineTrackArtists';
 import logger from '../../../logger';
+import { artistIdCache, normalizeKey, NOT_FOUND } from '../../../cache';
 import type { SpotifyAlbum, SpotifyArtist } from '../../../types';
 
 interface CurrentlyPlayingItem {
@@ -21,11 +22,20 @@ interface CurrentlyPlayingResponse {
 
 /**
  * Search Spotify for an artist by name and return their ID.
+ * Results are cached by normalized artist name.
  */
 async function resolveArtistId(spotifyApi: SpotifyApi, name: string): Promise<string | null> {
+  const cacheKey = normalizeKey(name);
+  const cached = artistIdCache.get(cacheKey);
+  if (cached !== undefined) {
+    return cached === NOT_FOUND ? null : cached;
+  }
+
   try {
     const results = await spotifyApi.search(name, ['artist'], undefined, 1);
-    return results.artists?.items?.[0]?.id || null;
+    const id = results.artists?.items?.[0]?.id || null;
+    artistIdCache.set(cacheKey, id ?? NOT_FOUND);
+    return id;
   } catch {
     return null;
   }

--- a/packages/server/src/spotify/api/helpers/getRelatedArtists.ts
+++ b/packages/server/src/spotify/api/helpers/getRelatedArtists.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import logger from '../../../logger';
+import { relatedArtistsCache, normalizeKey } from '../../../cache';
 import type { LastFmResponse, ListenBrainzResponse, MusicBrainzResponse } from '../../../types';
 
 const LASTFM_BASE = 'https://ws.audioscrobbler.com/2.0/';
@@ -87,6 +88,13 @@ async function fromListenBrainz(artistName: string, limit = 20): Promise<string[
  * Returns deduplicated array of artist names.
  */
 export default async function getRelatedArtists(artistName: string): Promise<string[]> {
+  const cacheKey = normalizeKey(artistName);
+  const cached = relatedArtistsCache.get(cacheKey);
+  if (cached) {
+    logger.info(`Related artists cache hit for "${artistName}" (${cached.length} artists)`);
+    return cached;
+  }
+
   // Run both in parallel -- Last.fm is fast, ListenBrainz adds diversity
   const [lastfmNames, lbNames] = await Promise.all([
     fromLastFm(artistName),
@@ -107,5 +115,9 @@ export default async function getRelatedArtists(artistName: string): Promise<str
   logger.info(
     `Related artists: ${combined.length} total (${lastfmNames.length} Last.fm + ${lbNames.length} ListenBrainz)`,
   );
+
+  if (combined.length > 0) {
+    relatedArtistsCache.set(cacheKey, combined);
+  }
   return combined;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       express-session:
         specifier: ^1.19.0
         version: 1.19.0
+      lru-cache:
+        specifier: ^11.3.5
+        version: 11.3.5
       passport:
         specifier: ^0.7.0
         version: 0.7.0
@@ -2238,6 +2241,10 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.3.5:
+    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
+    engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -5580,6 +5587,8 @@ snapshots:
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
+
+  lru-cache@11.3.5: {}
 
   lru-cache@5.1.1:
     dependencies:

--- a/thoughts/shared/tasks/12-ui-improvements.md
+++ b/thoughts/shared/tasks/12-ui-improvements.md
@@ -40,6 +40,7 @@ The original Zune periodically flipped individual tiles to reveal new album artw
 
 ### Loading improvements
 - When the song/app first loads, there should be UX that indicates something is loading (vs a blank screen).
+- If tiles could load in individually that would be ideal.
 
 ### Playback position
 - If there's way to implement song position UI (e.g. a bar at the bottom) without overloading the API/server, do it.

--- a/thoughts/shared/tasks/12-ui-improvements.md
+++ b/thoughts/shared/tasks/12-ui-improvements.md
@@ -38,6 +38,9 @@ The original Zune periodically flipped individual tiles to reveal new album artw
 - Ensure keyboard navigation works (fullscreen toggle, user menu).
 - Ensure sufficient color contrast for text over the overlay.
 
+### Loading improvements
+- When the song/app first loads, there should be UX that indicates something is loading (vs a blank screen).
+
 ## Visual reference
 
 See `assets/player.png`, `assets/player2.png`, and `docs/album-grid-requirements.md`.

--- a/thoughts/shared/tasks/12-ui-improvements.md
+++ b/thoughts/shared/tasks/12-ui-improvements.md
@@ -41,6 +41,9 @@ The original Zune periodically flipped individual tiles to reveal new album artw
 ### Loading improvements
 - When the song/app first loads, there should be UX that indicates something is loading (vs a blank screen).
 
+### Playback position
+- If there's way to implement song position UI (e.g. a bar at the bottom) without overloading the API/server, do it.
+
 ## Visual reference
 
 See `assets/player.png`, `assets/player2.png`, and `docs/album-grid-requirements.md`.


### PR DESCRIPTION
## Summary

Major UI polish to match the Zune aesthetic more closely.

### Mosaic grid
- 3 tile sizes (1x1, 2x2, 3x3) with 3 alternating templates
- GPU-accelerated diagonal drift animation (180s, 6 waypoints)
- Staggered tile fade-in on page load
- Cascade flip transition on song change (tiles flip one by one)

### Tile flip animation
- One random visible tile flips every 7-10 seconds
- Flips always show an album not already on screen
- 3D CSS rotateY with 0.8s transition

### Color extraction
- Dominant color extracted from album art via canvas sampling
- Overlay radiates the album's color with 3s transition
- Song card cover has subtle colored glow

### Song card
- Crossfade on song change (fade out, update, fade in)
- Text scales with clamp() instead of truncating with ellipsis
- Colored box-shadow from dominant color

### Progress bar
- Minimal bar at bottom center (250px max)
- Shows current time and total duration
- Ticks every second locally, corrects on 3s poll
- Pauses when playback is paused

### Error handling
- "Session expired" with reconnect button when Spotify token expires
- Rate limiting disabled in dev, increased for production

### Responsive + accessibility
- Mobile layout: smaller song card, hidden GitHub icon
- ARIA labels on fullscreen button and user menu
- Keyboard navigation (Enter/Space/Escape)
- Focus-visible outlines

## Test plan

- [ ] CI passes
- [ ] Mosaic loads with staggered fade-in
- [ ] Tiles flip periodically and on song change
- [ ] Color overlay shifts with current album
- [ ] Song card crossfades on song change
- [ ] Progress bar ticks smoothly
- [ ] Works on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)