### PR TITLE
feat: show connection error UI when polling fails

### DIFF
--- a/packages/client/src/contexts/SpotifyContext.tsx
+++ b/packages/client/src/contexts/SpotifyContext.tsx
@@ -93,10 +93,7 @@ function reducer(state: SpotifyState, action: SpotifyAction): SpotifyState {
       };
 
     case 'FETCH_NOW_PLAYING_FAILURE': {
-      const consecutiveErrors = Math.min(
-        state.consecutiveErrors + 1,
-        CONNECTION_LOST_THRESHOLD,
-      );
+      const consecutiveErrors = Math.min(state.consecutiveErrors + 1, CONNECTION_LOST_THRESHOLD);
       if (
         state.consecutiveErrors === consecutiveErrors &&
         state.initialized &&

--- a/packages/client/src/contexts/SpotifyContext.tsx
+++ b/packages/client/src/contexts/SpotifyContext.tsx
@@ -10,6 +10,8 @@ import {
 import { getPlaybackState, getRelatedAlbums } from '../api/spotify';
 import type { NowPlaying, RelatedAlbums, SpotifyAlbum } from '../types';
 
+const CONNECTION_LOST_THRESHOLD = 3;
+
 interface SpotifyState {
   nowPlaying: NowPlaying | null;
   relatedAlbums: RelatedAlbums;
@@ -17,6 +19,7 @@ interface SpotifyState {
   loading: boolean;
   albumsLoading: boolean;
   error: unknown;
+  consecutiveErrors: number;
 }
 
 type SpotifyAction =
@@ -36,6 +39,7 @@ interface FetchNowPlayingResult {
 }
 
 interface SpotifyContextValue extends SpotifyState {
+  connectionLost: boolean;
   fetchNowPlaying: (
     loadingRef: MutableRefObject<boolean>,
     currentSongId: string | null,
@@ -56,6 +60,7 @@ const initialState: SpotifyState = {
   loading: false,
   albumsLoading: false,
   error: null,
+  consecutiveErrors: 0,
 };
 
 function reducer(state: SpotifyState, action: SpotifyAction): SpotifyState {
@@ -69,6 +74,7 @@ function reducer(state: SpotifyState, action: SpotifyAction): SpotifyState {
         initialized: true,
         loading: false,
         error: null,
+        consecutiveErrors: 0,
         nowPlaying: action.payload,
       };
 
@@ -86,8 +92,26 @@ function reducer(state: SpotifyState, action: SpotifyAction): SpotifyState {
         },
       };
 
-    case 'FETCH_NOW_PLAYING_FAILURE':
-      return { ...state, initialized: true, loading: false, error: action.payload };
+    case 'FETCH_NOW_PLAYING_FAILURE': {
+      const consecutiveErrors = Math.min(
+        state.consecutiveErrors + 1,
+        CONNECTION_LOST_THRESHOLD,
+      );
+      if (
+        state.consecutiveErrors === consecutiveErrors &&
+        state.initialized &&
+        state.error != null
+      ) {
+        return state;
+      }
+      return {
+        ...state,
+        initialized: true,
+        loading: false,
+        error: action.payload,
+        consecutiveErrors,
+      };
+    }
 
     case 'CLEAR_RELATED_ALBUMS':
       return {
@@ -199,14 +223,17 @@ export function SpotifyProvider({ children }: SpotifyProviderProps) {
     dispatch({ type: 'CLEAR_RELATED_ALBUMS' });
   }, []);
 
+  const connectionLost = state.consecutiveErrors >= CONNECTION_LOST_THRESHOLD;
+
   const value = useMemo<SpotifyContextValue>(
     () => ({
       ...state,
+      connectionLost,
       fetchNowPlaying,
       fetchRelatedAlbums,
       clearRelatedAlbums,
     }),
-    [state, fetchNowPlaying, fetchRelatedAlbums, clearRelatedAlbums],
+    [state, connectionLost, fetchNowPlaying, fetchRelatedAlbums, clearRelatedAlbums],
   );
 
   return <SpotifyContext.Provider value={value}>{children}</SpotifyContext.Provider>;

--- a/packages/client/src/pages/VisualizationContent.css
+++ b/packages/client/src/pages/VisualizationContent.css
@@ -59,6 +59,12 @@
   gap: 16px;
 }
 
+.visualization__error--overlay {
+  position: absolute;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.75);
+}
+
 .visualization__error p {
   color: rgba(255, 255, 255, 0.7);
 }

--- a/packages/client/src/pages/VisualizationContent.tsx
+++ b/packages/client/src/pages/VisualizationContent.tsx
@@ -22,7 +22,7 @@ const REPO_URL = 'https://github.com/cdtinney/spune';
 export default function VisualizationContent() {
   useNowPlayingPoller();
   const { user, logout, login } = useUser();
-  const { nowPlaying, relatedAlbums, initialized, error } = useSpotify();
+  const { nowPlaying, relatedAlbums, initialized, error, connectionLost } = useSpotify();
   const windowSize = useWindowSize();
   const { tiles, gridCols, gridRows, base } = useAlbumGrid(relatedAlbums, windowSize);
   const dominantColor = useDominantColor(nowPlaying?.albumImageUrl);
@@ -88,16 +88,20 @@ export default function VisualizationContent() {
       <div className="visualization__content">
         {isInitialLoad && <LoadingScreen className="visualization__loading" />}
 
-        {!isInitialLoad && hasError && !songPlaying && (
-          <div className="visualization__error">
-            <p>Session expired or connection failed.</p>
+        {!isInitialLoad && (hasError || connectionLost) && (
+          <div
+            className={`visualization__error${songPlaying ? ' visualization__error--overlay' : ''}`}
+          >
+            <p>
+              {songPlaying ? 'Connection lost. Retrying…' : 'Session expired or connection failed.'}
+            </p>
             <button className="visualization__reconnect-btn" onClick={login}>
               Reconnect with Spotify
             </button>
           </div>
         )}
 
-        {!isInitialLoad && !hasError && !songPlaying && (
+        {!isInitialLoad && !hasError && !connectionLost && !songPlaying && (
           <div className="visualization__empty">
             <p>No song playing. Play something.</p>
           </div>


### PR DESCRIPTION
## Summary
- Tracks consecutive API poll failures in SpotifyContext via `consecutiveErrors` counter (capped at threshold to avoid no-op re-renders)
- After 3 consecutive failures (~9 seconds), shows a "Connection lost" error overlay with a "Reconnect with Spotify" button — even if a song was previously playing
- Derives `connectionLost` from the counter rather than storing redundant boolean state

## Test plan
- [ ] Start playing a song, then stop the server — verify the error overlay appears after ~9 seconds
- [ ] Restart the server — verify the UI recovers and the overlay disappears
- [ ] Stop the server when no song is playing — verify the existing "Session expired or connection failed" error screen still shows
- [ ] All 21 existing client tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)