### PR TITLE
feat: Task 15 — AI-agent friendly repo docs and CI guardrails

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,13 +5,3 @@
 ## Test plan
 
 <!-- How was this tested? -->
-
-## Checklist
-
-- [ ] `./scripts/pre-pr.sh` passes locally
-- [ ] Formatting: `pnpm format:check`
-- [ ] Linting: `pnpm lint`
-- [ ] Client tests: `pnpm client:test`
-- [ ] Server tests: `pnpm server:test`
-- [ ] Client build: `pnpm client:build`
-- [ ] Types: `pnpm --filter spune-client exec tsc --noEmit` and `pnpm --filter spune-server exec tsc --noEmit`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,17 @@
 ## Summary
 
+<!-- Brief description of what this PR does and why. -->
+
 ## Test plan
+
+<!-- How was this tested? -->
+
+## Checklist
+
+- [ ] `./scripts/pre-pr.sh` passes locally
+- [ ] Formatting: `pnpm format:check`
+- [ ] Linting: `pnpm lint`
+- [ ] Client tests: `pnpm client:test`
+- [ ] Server tests: `pnpm server:test`
+- [ ] Client build: `pnpm client:build`
+- [ ] Types: `pnpm --filter spune-client exec tsc --noEmit` and `pnpm --filter spune-server exec tsc --noEmit`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Test
         run: pnpm server:test:coverage
 
+      - name: Type check
+        run: pnpm --filter spune-server exec tsc --noEmit
+
   client:
     runs-on: ubuntu-latest
 
@@ -107,6 +110,9 @@ jobs:
 
       - name: Build
         run: pnpm client:build
+
+      - name: Type check
+        run: pnpm --filter spune-client exec tsc --noEmit
 
   docker:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,137 @@
+# AGENTS.md
+
+> Guide for AI coding agents working in this repository.
+
+## Project Overview
+
+**Spune** is a Zune-inspired Spotify "Now Playing" visualizer. A React SPA polls a custom Express back-end for the currently playing track, then renders a Zune-style animated mosaic of related artist album covers as the background.
+
+This is a **pnpm monorepo** with two packages:
+
+| Package           | Name           | Description              |
+| ----------------- | -------------- | ------------------------ |
+| `packages/client` | `spune-client` | React 19 + Vite SPA      |
+| `packages/server` | `spune-server` | Express + TypeScript API |
+
+### Monorepo Structure
+
+```
+packages/
+  client/                # React 19 + Vite SPA
+    src/
+      api/               # Axios API calls to the server
+      components/        # UI components (AlbumGrid, SongCard, etc.)
+      contexts/          # React contexts (UserContext, SpotifyContext)
+      hooks/             # Custom hooks (useNowPlayingPoller, useAlbumGrid, etc.)
+      pages/             # Page components (Home, Visualization, Error)
+      types/             # TypeScript types (spotify.ts, ui.ts)
+  server/                # Express + TypeScript API
+    src/
+      auth/              # Passport.js serialization/deserialization
+      cache/             # LRU caches for related artists, artist IDs, artist albums
+      config/            # App configuration and path helpers
+      database/          # PostgreSQL pool, migrations, and user queries
+      logger/            # Winston logger setup
+      middleware/        # Express middleware (rate limiting)
+      routes/            # API route handlers (auth, spotify)
+      spotify/           # Spotify API integration and album discovery pipeline
+      types/             # TypeScript types (user, spotify, external APIs)
+```
+
+## Architecture
+
+### Client-Server Communication
+
+The client is a Vite SPA served at `127.0.0.1:3000` in dev. All `/api/*` requests are proxied to the Express server at `127.0.0.1:5000` via Vite's dev proxy. In production, the Express server serves the built client as static files.
+
+Three API endpoints:
+
+- `GET /api/auth/user` — returns the authenticated user (or empty object)
+- `GET /api/spotify/me/player` — returns the current playback state
+- `GET /api/spotify/currently-playing/related-albums?songId=<id>` — returns related artist albums
+
+The client polls `/api/spotify/me/player` every 3 seconds. When the album changes, it fetches related albums.
+
+### Auth Flow
+
+1. User clicks Login → `window.location.assign('/api/auth/spotify')`
+2. Passport redirects to Spotify OAuth (scopes: `user-read-private`, `user-read-email`, `user-read-playback-state`)
+3. Spotify redirects to `SPOT_REDIRECT_URI` → `/api/auth/spotify/callback`
+4. Passport verify callback upserts the user in PostgreSQL with access/refresh tokens
+5. Success redirects to `CLIENT_HOST/#/visualization`
+6. On every subsequent request, `deserializeUser` loads the user from DB by `spotifyId` stored in the session
+7. Token refresh: `apiRequestWithRefresh` checks if `tokenUpdated + expiresIn <= Date.now()` and refreshes via `passport-oauth2-refresh` if expired
+
+### Album Discovery Pipeline
+
+Entry: `getCurrentlyPlayingRelatedAlbums(spotifyApi, songId)` in `packages/server/src/spotify/api/helpers/getCurrentlyPlayingRelatedAlbums.ts`
+
+1. Verify the `songId` matches the currently playing track
+2. Collect track artist IDs from both song and album artists
+3. Fetch track artists' own albums via Spotify API (cached 30 min)
+4. Fetch related artist names from **Last.fm** and **ListenBrainz** in parallel (cached 1 hour)
+5. Resolve related artist names to Spotify IDs (in batches of 5, cached 1 hour including "not found")
+6. Fetch related artist albums until ≥200 total (cached 30 min)
+7. Combine and deduplicate (strip edition suffixes like "Deluxe Edition"), track artist albums first
+
+## Key Conventions
+
+- **TypeScript**: `strict: true` in both packages. Client uses `noEmit` (Vite transpiles). Server compiles to CommonJS in `dist/`.
+- **Testing**: Vitest for both packages. Client uses `jsdom` environment + `@testing-library/react`. Server uses `node` environment. Tests live in `src/__tests__/` or `src/**/__tests__/`.
+- **Formatting**: Prettier (single quotes, trailing commas, 100 char width, 2-space indent). Run `pnpm format:check` to verify.
+- **Linting**: ESLint v9 flat config with `typescript-eslint` recommended. `eslint-config-prettier` disables style rules. Unused vars prefixed `_` are allowed.
+- **Package manager**: pnpm 10 with workspaces. Always use `pnpm`, never `npm` or `yarn`.
+- **Routing**: Hash-based routing (`HashRouter`) so the server only needs to serve `index.html`.
+
+## Common Tasks
+
+### Add a new API endpoint
+
+1. Add the route handler in `packages/server/src/routes/` (either `auth.ts` or `spotify.ts`, or create a new file).
+2. If creating a new route file, mount it in `packages/server/src/routes/index.ts`.
+3. Add an API function in `packages/client/src/api/` to call the endpoint.
+4. Add tests for the route handler.
+
+### Add a new React component
+
+1. Create the component file in `packages/client/src/components/`.
+2. Add types to `packages/client/src/types/` if needed.
+3. Import and use in the appropriate page or parent component.
+4. Add tests in `packages/client/src/__tests__/` or a co-located `__tests__` directory.
+
+### Add a database migration
+
+1. Create a new SQL file in `packages/server/src/database/migrations/` (e.g., `002_description.sql`).
+2. Update `docker-compose.dev.yml` and `docker-compose.yml` to mount the new migration file.
+3. Update the CI workflow to run the new migration in the `server` job.
+
+## Gotchas
+
+- **Spotify redirect URI must use `127.0.0.1`**, not `localhost`, for local development. Spotify's OAuth doesn't support `localhost`.
+- **Session cookie port mismatch**: In dev, `SPOT_REDIRECT_URI` must point to port 3000 (Vite), not 5000 (Express). The Vite proxy forwards the callback to Express, and the session cookie must be set on the origin the browser visits.
+- **dotenv load order**: `packages/server/app.ts` uses dynamic `import()` to ensure `dotenv.config()` runs before any module-level code reads `process.env`. Do not add top-level imports of modules that read env vars.
+- **Rate limiting disabled in dev**: All rate limiters in `packages/server/src/middleware/rateLimiter.ts` are passthrough when `NODE_ENV !== 'production'`.
+- **`trust proxy: 1`** is set in `createApp.ts` for Caddy reverse proxy in production. Don't remove this.
+- **`LAST_FM_API_KEY`** is optional. If unset, only ListenBrainz is used for related artist discovery.
+- **Client build output**: Goes to `packages/client/build/`, not the default `dist/`.
+- **Server tests need Spotify env vars**: Route tests that call `createApp()` require `SPOT_CLIENT_ID`, `SPOT_CLIENT_SECRET`, and `SPOT_REDIRECT_URI` to be set (any non-empty value works). The `scripts/pre-pr.sh` script sets test defaults automatically. CI also sets these in the `server` job.
+
+## Pre-PR Checklist
+
+Run the full validation suite locally before opening a PR:
+
+```bash
+./scripts/pre-pr.sh
+```
+
+This runs:
+
+1. `pnpm format:check` — Prettier formatting
+2. `pnpm lint` — ESLint for both packages
+3. `pnpm client:test` — Client Vitest tests
+4. `pnpm server:test` — Server Vitest tests
+5. `pnpm client:build` — Client production build
+6. `pnpm --filter spune-client exec tsc --noEmit` — Client type check
+7. `pnpm --filter spune-server exec tsc --noEmit` — Server type check
+
+All checks must pass. CI runs these same checks on every push and PR to `master`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing
+
+## Setup
+
+See the [README](README.md) for full setup instructions. In short:
+
+```bash
+git clone git@github.com:cdtinney/spune.git
+cd spune
+pnpm install
+cp packages/server/.env.example packages/server/.env
+# Edit .env with your credentials
+pnpm dev
+```
+
+## Branch Naming
+
+Use the format: `task/NN-description`
+
+Examples:
+
+- `task/15-ai-agent-friendly`
+- `task/08-typescript-migration`
+
+## Commit Messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add related artist caching
+fix: correct session cookie domain in dev
+docs: update README setup instructions
+refactor: extract album dedup logic
+test: add tests for token refresh
+chore: update dependencies
+```
+
+## PR Process
+
+1. Branch off `master`.
+2. Make your changes.
+3. Run the full check suite locally:
+   ```bash
+   ./scripts/pre-pr.sh
+   ```
+4. Push your branch and open a PR against `master`.
+5. CI must pass (format, lint, test, build).
+6. PRs are squash-merged.
+
+## Running Checks Locally
+
+The `scripts/pre-pr.sh` script runs the full CI suite:
+
+```bash
+./scripts/pre-pr.sh
+```
+
+This runs formatting, linting, tests, build, and type-checking for both packages. Run this before pushing to catch issues early.
+
+Individual checks:
+
+```bash
+pnpm format:check           # Prettier
+pnpm lint                   # ESLint (both packages)
+pnpm client:test            # Client tests
+pnpm server:test            # Server tests
+pnpm client:build           # Client build
+pnpm --filter spune-client exec tsc --noEmit  # Client types
+pnpm --filter spune-server exec tsc --noEmit  # Server types
+```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Spune displays album artwork from related artists in a Zune-style mosaic while y
 ```bash
 git clone git@github.com:cdtinney/spune.git
 cd spune
-npm install
+pnpm install
 ```
 
 Create `packages/server/.env` from the example:
@@ -57,7 +57,7 @@ Edit `.env` and fill in your credentials:
 ### Running (Development)
 
 ```bash
-npm run dev
+pnpm dev
 ```
 
 This starts both the Express server (port 5000) and Vite dev server (port 3000) concurrently. Open `http://127.0.0.1:3000`.
@@ -67,16 +67,16 @@ The Vite dev server proxies `/api` requests to the Express server, so the redire
 ### Testing
 
 ```bash
-npm run client:test         # Client tests (Vitest)
-npm run client:lint          # Client lint (ESLint)
-npm run server:test:coverage # Server tests (Jest)
-npm run server:lint          # Server lint (ESLint)
+pnpm client:test         # Client tests (Vitest)
+pnpm client:lint          # Client lint (ESLint)
+pnpm server:test:coverage # Server tests (Jest)
+pnpm server:lint          # Server lint (ESLint)
 ```
 
 ### Building
 
 ```bash
-npm run client:build   # Builds to packages/client/build/
+pnpm client:build   # Builds to packages/client/build/
 ```
 
 ## Docker

--- a/packages/client/src/components/__tests__/SongCard.test.tsx
+++ b/packages/client/src/components/__tests__/SongCard.test.tsx
@@ -10,6 +10,7 @@ describe('SongCard', () => {
         songTitle="Test Song"
         albumName="Test Album"
         albumImageUrl="http://img/cover.jpg"
+        songId="test-song-id"
       />,
     );
 

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Server route tests need Spotify env vars (any non-empty value works for tests).
+export SPOT_CLIENT_ID="${SPOT_CLIENT_ID:-test}"
+export SPOT_CLIENT_SECRET="${SPOT_CLIENT_SECRET:-test}"
+export SPOT_REDIRECT_URI="${SPOT_REDIRECT_URI:-http://localhost:3000/callback}"
+
+echo "=== Format check ==="
+pnpm format:check
+
+echo ""
+echo "=== Lint ==="
+pnpm lint
+
+echo ""
+echo "=== Client tests ==="
+pnpm client:test
+
+echo ""
+echo "=== Server tests ==="
+pnpm server:test
+
+echo ""
+echo "=== Client build ==="
+pnpm client:build
+
+echo ""
+echo "=== Type check (client) ==="
+pnpm --filter spune-client exec tsc --noEmit
+
+echo ""
+echo "=== Type check (server) ==="
+pnpm --filter spune-server exec tsc --noEmit
+
+echo ""
+echo "All checks passed."


### PR DESCRIPTION
## Summary

- **AGENTS.md**: Project overview, architecture (auth flow, album discovery pipeline), conventions, common tasks, gotchas, and pre-PR checklist for AI coding agents
- **CONTRIBUTING.md**: Setup instructions, branch naming, commit format, PR process, and local check commands
- **scripts/pre-pr.sh**: Full local validation script (format, lint, tests, build, type-check) with stub env vars for server tests
- **PR template**: Enhanced with checklist covering all CI checks
- **CI**: Added `tsc --noEmit` type-check steps to both client and server jobs
- **Bug fix**: Added missing `songId` prop to SongCard test (pre-existing type error caught by new type-check)
- **README**: Updated `npm` references to `pnpm`

## Test plan

- [x] `./scripts/pre-pr.sh` passes locally (format, lint, 70 tests, build, type-check)
- [x] Verified no remaining references to `check.sh`
- [x] Verified type errors are caught by new CI steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)