### PR TITLE
refactor: extract CSS design tokens, name magic values, and deduplicate code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,30 @@ The `scripts/pre-pr.sh` script runs the full CI suite:
 
 This runs formatting, linting, tests, build, and type-checking for both packages. Run this before pushing to catch issues early.
 
+## Code Quality
+
+### CSS
+
+- **Use design tokens** — Shared colors, spacing, shadows, z-index layers, and border radius are defined as CSS custom properties in `packages/client/src/index.css` under `:root`. Always use `var(--token-name)` instead of hardcoding values like `#1db954` or `30px`.
+- **Use utility classes** before writing component-specific styles:
+  - `.btn-primary` — Spotify-green button with hover state
+  - `.icon-interactive` — Text color with dimmed hover/focus state for icon buttons and links
+  - `.focus-ring` — Spotify-green focus-visible outline for keyboard accessibility
+- **Don't redeclare inherited styles** — Page containers inherit `background-color` and `font-family` from `body`. Don't repeat them.
+
+### Naming
+
+- **Constants** — `SCREAMING_SNAKE_CASE` with descriptive names and units: `TILE_SIZE_PX`, `RESIZE_DEBOUNCE_MS`, not `BASE` or `300`.
+- **Booleans** — Props and interface fields use `is`/`has` prefixes (`isPlaying`, `hasError`). Local component state uses bare adjectives (`visible`, `open`).
+- **Callbacks** — Props use `on` prefix (`onClick`, `onLogout`). Internal handlers use `handle` prefix (`handleResize`).
+- **Action types** — Use the `ActionType` const object in `SpotifyContext.tsx`, not string literals.
+
+### Avoiding Duplication
+
+- **Error extraction** — Use `errorMessage(error)` from `packages/server/src/utils/errorMessage.ts` instead of inlining `error instanceof Error` checks.
+- **Rate limiters** — Use `createLimiter(max, message)` in `rateLimiter.ts` to add new limiters.
+- **Test mocks** — Use `mockUseUser()` from `packages/client/src/__tests__/helpers/mockUserContext.ts` instead of repeating the full mock shape. Only pass overrides for what your test cares about.
+
 Individual checks:
 
 ```bash

--- a/packages/client/src/__tests__/helpers/mockUserContext.ts
+++ b/packages/client/src/__tests__/helpers/mockUserContext.ts
@@ -1,0 +1,23 @@
+import { vi } from 'vitest';
+import type { UserProfile } from '../../types';
+import * as UserContext from '../../contexts/UserContext';
+
+export function mockUseUser(
+  overrides: Partial<{
+    user: UserProfile | null;
+    loading: boolean;
+    error: string | null;
+    login: () => void;
+    logout: () => void;
+  }> = {},
+) {
+  const mockedUserContext = vi.mocked(UserContext, true);
+  mockedUserContext.useUser.mockReturnValue({
+    user: null,
+    loading: false,
+    error: null,
+    login: vi.fn(),
+    logout: vi.fn(),
+    ...overrides,
+  });
+}

--- a/packages/client/src/__tests__/routes.test.tsx
+++ b/packages/client/src/__tests__/routes.test.tsx
@@ -2,24 +2,16 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import AppRoutes from '../routes';
-import * as UserContext from '../contexts/UserContext';
+import { mockUseUser } from './helpers/mockUserContext';
 
 vi.mock('../contexts/UserContext');
 vi.mock('../pages/VisualizationPage', () => ({
   default: () => <div>VisualizationPage</div>,
 }));
 
-const mockedUserContext = vi.mocked(UserContext, true);
-
 describe('AppRoutes', () => {
   it('redirects / to /home', () => {
-    mockedUserContext.useUser.mockReturnValue({
-      user: null,
-      loading: false,
-      error: null,
-      login: vi.fn(),
-      logout: vi.fn(),
-    });
+    mockUseUser();
 
     render(
       <MemoryRouter initialEntries={['/']}>
@@ -31,13 +23,7 @@ describe('AppRoutes', () => {
   });
 
   it('redirects /visualization to / when not authenticated', () => {
-    mockedUserContext.useUser.mockReturnValue({
-      user: null,
-      loading: false,
-      error: null,
-      login: vi.fn(),
-      logout: vi.fn(),
-    });
+    mockUseUser();
 
     render(
       <MemoryRouter initialEntries={['/visualization']}>
@@ -49,13 +35,7 @@ describe('AppRoutes', () => {
   });
 
   it('renders visualization page when authenticated', () => {
-    mockedUserContext.useUser.mockReturnValue({
-      user: { spotifyId: 'user1', displayName: 'Test' },
-      loading: false,
-      error: null,
-      login: vi.fn(),
-      logout: vi.fn(),
-    });
+    mockUseUser({ user: { spotifyId: 'user1', displayName: 'Test' } });
 
     render(
       <MemoryRouter initialEntries={['/visualization']}>
@@ -67,13 +47,7 @@ describe('AppRoutes', () => {
   });
 
   it('renders error page', () => {
-    mockedUserContext.useUser.mockReturnValue({
-      user: null,
-      loading: false,
-      error: null,
-      login: vi.fn(),
-      logout: vi.fn(),
-    });
+    mockUseUser();
 
     render(
       <MemoryRouter initialEntries={['/error/test%20error']}>

--- a/packages/client/src/cast/receiver/ReceiverApp.tsx
+++ b/packages/client/src/cast/receiver/ReceiverApp.tsx
@@ -125,7 +125,12 @@ export default function ReceiverApp() {
             {!connected && !songPlaying && <LoadingScreen className="visualization__loading" />}
 
             {songPlaying && (
-              <AlbumGrid tiles={tiles} gridCols={gridCols} gridRows={gridRows} tileSize={tileSize} />
+              <AlbumGrid
+                tiles={tiles}
+                gridCols={gridCols}
+                gridRows={gridRows}
+                tileSize={tileSize}
+              />
             )}
           </div>
 

--- a/packages/client/src/cast/receiver/ReceiverApp.tsx
+++ b/packages/client/src/cast/receiver/ReceiverApp.tsx
@@ -42,7 +42,7 @@ export default function ReceiverApp() {
 
   const dominantColor = useDominantColor(nowPlaying?.albumImageUrl);
   const windowSize = useWindowSize();
-  const { tiles, gridCols, gridRows, base } = useAlbumGrid(relatedAlbums, windowSize);
+  const { tiles, gridCols, gridRows, tileSize } = useAlbumGrid(relatedAlbums, windowSize);
 
   const handleMessage = useCallback((event: cast.framework.system.Event) => {
     try {
@@ -125,7 +125,7 @@ export default function ReceiverApp() {
             {!connected && !songPlaying && <LoadingScreen className="visualization__loading" />}
 
             {songPlaying && (
-              <AlbumGrid tiles={tiles} gridCols={gridCols} gridRows={gridRows} base={base} />
+              <AlbumGrid tiles={tiles} gridCols={gridCols} gridRows={gridRows} tileSize={tileSize} />
             )}
           </div>
 

--- a/packages/client/src/components/AlbumGrid.tsx
+++ b/packages/client/src/components/AlbumGrid.tsx
@@ -3,11 +3,18 @@ import FlippableTile from './FlippableTile';
 import type { Album } from '../types';
 import './AlbumGrid.css';
 
+const CASCADE_FLIP_STAGGER_MS = 50;
+const AMBIENT_FLIP_INITIAL_DELAY_MS = 7000;
+const AMBIENT_FLIP_JITTER_MS = 3000;
+const ENTRANCE_STAGGER_MS = 15;
+const CHANGE_DETECTION_SAMPLE_SIZE = 20;
+const VIEWPORT_OVERSCAN_TILES = 2;
+
 interface AlbumGridProps {
   tiles: Album[];
   gridCols: number;
   gridRows: number;
-  base: number;
+  tileSize: number;
 }
 
 interface FlipEntry {
@@ -17,9 +24,9 @@ interface FlipEntry {
 
 type FlipMap = Record<number, FlipEntry>;
 
-export default function AlbumGrid({ tiles, gridCols, gridRows, base }: AlbumGridProps) {
+export default function AlbumGrid({ tiles, gridCols, gridRows, tileSize }: AlbumGridProps) {
   const [flipMap, setFlipMap] = useState<FlipMap>({});
-  const imagePoolRef = useRef(0);
+  const imageIndexRef = useRef(0);
   const flipCounterRef = useRef(1);
   const prevTileIdsRef = useRef('');
 
@@ -29,17 +36,17 @@ export default function AlbumGrid({ tiles, gridCols, gridRows, base }: AlbumGrid
   );
 
   const visibleTileIndices = useMemo(() => {
-    const maxCol = Math.ceil(window.innerWidth / base) + 2;
-    const maxRow = Math.ceil(window.innerHeight / base) + 2;
+    const maxCol = Math.ceil(window.innerWidth / tileSize) + VIEWPORT_OVERSCAN_TILES;
+    const maxRow = Math.ceil(window.innerHeight / tileSize) + VIEWPORT_OVERSCAN_TILES;
     return tiles
       .map((tile, index) => ({ tile, index }))
       .filter(({ tile }) => tile.col <= maxCol && tile.row <= maxRow)
       .map(({ index }) => index);
-  }, [tiles, base]);
+  }, [tiles, tileSize]);
 
   // Cascade flip on song change
   useEffect(() => {
-    const currentIds = allImageUrls.slice(0, 20).join(',');
+    const currentIds = allImageUrls.slice(0, CHANGE_DETECTION_SAMPLE_SIZE).join(',');
     if (currentIds === prevTileIdsRef.current || tiles.length === 0) {
       prevTileIdsRef.current = currentIds;
       return;
@@ -60,7 +67,7 @@ export default function AlbumGrid({ tiles, gridCols, gridRows, base }: AlbumGrid
           const key = flipCounterRef.current++;
           setFlipMap((prev) => ({ ...prev, [tileIndex]: { url: newImage, key } }));
         }
-      }, i * 50);
+      }, i * CASCADE_FLIP_STAGGER_MS);
       timers.push(timer);
     });
 
@@ -78,8 +85,8 @@ export default function AlbumGrid({ tiles, gridCols, gridRows, base }: AlbumGrid
 
     let nextImage: string | undefined;
     for (let attempt = 0; attempt < allImageUrls.length; attempt++) {
-      const candidate = allImageUrls[imagePoolRef.current % allImageUrls.length];
-      imagePoolRef.current++;
+      const candidate = allImageUrls[imageIndexRef.current % allImageUrls.length];
+      imageIndexRef.current++;
       if (!visibleImages.has(candidate)) {
         nextImage = candidate;
         break;
@@ -87,8 +94,8 @@ export default function AlbumGrid({ tiles, gridCols, gridRows, base }: AlbumGrid
     }
 
     if (!nextImage) {
-      nextImage = allImageUrls[imagePoolRef.current % allImageUrls.length];
-      imagePoolRef.current++;
+      nextImage = allImageUrls[imageIndexRef.current % allImageUrls.length];
+      imageIndexRef.current++;
     }
 
     if (nextImage) {
@@ -100,8 +107,11 @@ export default function AlbumGrid({ tiles, gridCols, gridRows, base }: AlbumGrid
   useEffect(() => {
     if (tiles.length === 0) return;
 
-    const firstTimeout = setTimeout(flipRandomTile, 7000);
-    const interval = setInterval(flipRandomTile, 7000 + Math.random() * 3000);
+    const firstTimeout = setTimeout(flipRandomTile, AMBIENT_FLIP_INITIAL_DELAY_MS);
+    const interval = setInterval(
+      flipRandomTile,
+      AMBIENT_FLIP_INITIAL_DELAY_MS + Math.random() * AMBIENT_FLIP_JITTER_MS,
+    );
 
     return () => {
       clearTimeout(firstTimeout);
@@ -118,13 +128,13 @@ export default function AlbumGrid({ tiles, gridCols, gridRows, base }: AlbumGrid
       <div
         className="album-grid"
         style={{
-          gridTemplateColumns: `repeat(${gridCols}, ${base}px)`,
-          gridTemplateRows: `repeat(${gridRows}, ${base}px)`,
+          gridTemplateColumns: `repeat(${gridCols}, ${tileSize}px)`,
+          gridTemplateRows: `repeat(${gridRows}, ${tileSize}px)`,
         }}
       >
         {tiles.map((tile, index) => {
           const isVisible = visibleTileIndices.includes(index);
-          const entranceDelay = isVisible ? index * 15 : 0;
+          const entranceDelay = isVisible ? index * ENTRANCE_STAGGER_MS : 0;
           const flip = flipMap[index];
 
           return (

--- a/packages/client/src/components/FullscreenButton.css
+++ b/packages/client/src/components/FullscreenButton.css
@@ -1,25 +1,10 @@
 .fullscreen-button {
   position: absolute;
-  right: 30px;
-  bottom: 30px;
-  z-index: 100;
+  right: var(--spacing-overlay-inset);
+  bottom: var(--spacing-overlay-inset);
+  z-index: var(--z-overlay-chrome);
   cursor: pointer;
   background: none;
   border: none;
   padding: 8px;
-}
-
-.fullscreen-button__icon {
-  color: rgba(255, 255, 255, 0.87);
-}
-
-.fullscreen-button:hover .fullscreen-button__icon,
-.fullscreen-button:focus-visible .fullscreen-button__icon {
-  color: rgba(255, 255, 255, 0.54);
-}
-
-.fullscreen-button:focus-visible {
-  outline: 2px solid #1db954;
-  outline-offset: 2px;
-  border-radius: 4px;
 }

--- a/packages/client/src/components/FullscreenButton.tsx
+++ b/packages/client/src/components/FullscreenButton.tsx
@@ -9,7 +9,7 @@ interface FullscreenButtonProps {
 export default function FullscreenButton({ onClick }: FullscreenButtonProps) {
   return (
     <button
-      className="fullscreen-button"
+      className="fullscreen-button icon-interactive focus-ring"
       onClick={onClick}
       aria-label="Toggle fullscreen"
       title="Toggle fullscreen"

--- a/packages/client/src/components/LoadingScreen.css
+++ b/packages/client/src/components/LoadingScreen.css
@@ -9,7 +9,7 @@
   width: 40px;
   height: 40px;
   border: 3px solid rgba(255, 255, 255, 0.2);
-  border-top-color: #1db954;
+  border-top-color: var(--color-spotify-green);
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
 }

--- a/packages/client/src/components/ProgressBar.css
+++ b/packages/client/src/components/ProgressBar.css
@@ -3,7 +3,7 @@
   bottom: 0;
   left: 50%;
   transform: translateX(-50%);
-  z-index: 100;
+  z-index: var(--z-overlay-chrome);
   display: flex;
   align-items: center;
   gap: 8px;

--- a/packages/client/src/components/SongCard.css
+++ b/packages/client/src/components/SongCard.css
@@ -3,9 +3,9 @@
   position: absolute;
   flex-wrap: wrap;
   align-items: center;
-  left: 30px;
-  bottom: 30px;
-  z-index: 100;
+  left: var(--spacing-overlay-inset);
+  bottom: var(--spacing-overlay-inset);
+  z-index: var(--z-overlay-chrome);
   transition: opacity 0.5s ease-in-out;
 }
 
@@ -27,10 +27,7 @@
   transition:
     background-image 1s ease-in 1s,
     box-shadow 3s ease-in-out;
-  box-shadow:
-    0 3px 5px -1px rgba(0, 0, 0, 0.2),
-    0 6px 10px 0 rgba(0, 0, 0, 0.14),
-    0 1px 18px 0 rgba(0, 0, 0, 0.12);
+  box-shadow: var(--shadow-elevation-3);
 }
 
 .song-card__details {
@@ -40,7 +37,7 @@
 }
 
 .song-card__text {
-  color: rgba(255, 255, 255, 0.87);
+  color: var(--color-text-primary);
   text-shadow: 2px 2px 7px rgba(94, 94, 94, 0.44);
   padding: 0;
   word-wrap: break-word;
@@ -61,10 +58,11 @@
   margin-top: 0.8em;
 }
 
+/* Breakpoint: 600px */
 @media (max-width: 600px) {
   .song-card {
-    left: 15px;
-    bottom: 15px;
+    left: var(--spacing-overlay-inset-mobile);
+    bottom: var(--spacing-overlay-inset-mobile);
   }
 
   .song-card__cover {

--- a/packages/client/src/components/SongCard.tsx
+++ b/packages/client/src/components/SongCard.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
 import './SongCard.css';
 
+const SONG_CARD_FADE_MS = 500;
+
 interface SongCardProps {
   artistName: string;
   songTitle: string;
@@ -37,7 +39,7 @@ export default function SongCard({
     const timer = setTimeout(() => {
       setDisplayedSong({ artistName, songTitle, albumName, albumImageUrl, songId });
       setVisible(true);
-    }, 500);
+    }, SONG_CARD_FADE_MS);
 
     return () => clearTimeout(timer);
   }, [songId, artistName, songTitle, albumName, albumImageUrl, displayedSong.songId]);

--- a/packages/client/src/components/SpotifyLoginButton.css
+++ b/packages/client/src/components/SpotifyLoginButton.css
@@ -1,23 +1,3 @@
-.spotify-login-button {
-  display: inline-flex;
-  align-items: center;
-  padding: 10px 24px;
-  background-color: #1db954;
-  color: #fff;
-  border: none;
-  border-radius: 4px;
-  font-family: 'Source Sans Pro', sans-serif;
-  font-size: 0.875rem;
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.spotify-login-button:hover {
-  background-color: #1ed760;
-}
-
 .spotify-login-button__icon {
   margin-right: 10px;
 }

--- a/packages/client/src/components/SpotifyLoginButton.tsx
+++ b/packages/client/src/components/SpotifyLoginButton.tsx
@@ -8,7 +8,7 @@ interface SpotifyLoginButtonProps {
 
 export default function SpotifyLoginButton({ onClick }: SpotifyLoginButtonProps) {
   return (
-    <button id="button-login" className="spotify-login-button" onClick={onClick}>
+    <button id="button-login" className="btn-primary spotify-login-button" onClick={onClick}>
       <FontAwesomeIcon icon={faSpotify} size="lg" className="spotify-login-button__icon" />
       LOG IN WITH SPOTIFY
     </button>

--- a/packages/client/src/components/UserAvatar.css
+++ b/packages/client/src/components/UserAvatar.css
@@ -1,36 +1,32 @@
 .user-avatar {
+  --avatar-size: 32px;
+
   display: flex;
   align-items: center;
 }
 
 .user-avatar__image {
-  width: 32px;
-  height: 32px;
+  width: var(--avatar-size);
+  height: var(--avatar-size);
   border-radius: 50%;
-  box-shadow:
-    0 3px 5px -1px rgba(0, 0, 0, 0.2),
-    0 6px 10px 0 rgba(0, 0, 0, 0.14),
-    0 1px 18px 0 rgba(0, 0, 0, 0.12);
+  box-shadow: var(--shadow-elevation-3);
 }
 
 .user-avatar__placeholder {
-  width: 32px;
-  height: 32px;
+  width: var(--avatar-size);
+  height: var(--avatar-size);
   border-radius: 50%;
-  background-color: #1db954;
+  background-color: var(--color-spotify-green);
   color: #fff;
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 14px;
   font-weight: 600;
-  box-shadow:
-    0 3px 5px -1px rgba(0, 0, 0, 0.2),
-    0 6px 10px 0 rgba(0, 0, 0, 0.14),
-    0 1px 18px 0 rgba(0, 0, 0, 0.12);
+  box-shadow: var(--shadow-elevation-3);
 }
 
 .user-avatar__name {
   margin-left: 10px;
-  color: rgba(255, 255, 255, 0.87);
+  color: var(--color-text-primary);
 }

--- a/packages/client/src/components/UserMenu.css
+++ b/packages/client/src/components/UserMenu.css
@@ -12,32 +12,15 @@
   cursor: pointer;
 }
 
-.user-menu__trigger:focus-visible {
-  outline: 2px solid #1db954;
-  outline-offset: 2px;
-  border-radius: 4px;
-}
-
-.user-menu__icon {
-  color: rgba(255, 255, 255, 0.87);
-}
-
-.user-menu__trigger:hover .user-menu__icon {
-  color: rgba(255, 255, 255, 0.54);
-}
-
 .user-menu__dropdown {
   position: absolute;
   top: 100%;
   right: 0;
   margin-top: 10px;
-  background-color: #424242;
-  border-radius: 4px;
-  box-shadow:
-    0 3px 5px -1px rgba(0, 0, 0, 0.2),
-    0 6px 10px 0 rgba(0, 0, 0, 0.14),
-    0 1px 18px 0 rgba(0, 0, 0, 0.12);
-  z-index: 200;
+  background-color: var(--color-bg-surface);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-elevation-3);
+  z-index: var(--z-dropdown);
   min-width: 80px;
 }
 
@@ -47,8 +30,7 @@
   padding: 5px 10px;
   border: none;
   background: none;
-  color: rgba(255, 255, 255, 0.87);
-  font-family: 'Source Sans Pro', sans-serif;
+  color: var(--color-text-primary);
   font-size: 0.8rem;
   text-align: left;
   cursor: pointer;

--- a/packages/client/src/components/UserMenu.tsx
+++ b/packages/client/src/components/UserMenu.tsx
@@ -32,7 +32,7 @@ export default function UserMenu({ onLogout }: UserMenuProps) {
   return (
     <div className="user-menu" ref={menuRef}>
       <button
-        className="user-menu__trigger"
+        className="user-menu__trigger icon-interactive focus-ring"
         onClick={() => setOpen(!open)}
         onKeyDown={handleKeyDown}
         aria-label="User menu"

--- a/packages/client/src/components/__tests__/AlbumGrid.test.tsx
+++ b/packages/client/src/components/__tests__/AlbumGrid.test.tsx
@@ -11,7 +11,7 @@ const mockTiles: Album[] = [
 describe('AlbumGrid', () => {
   it('renders a tile for each album', () => {
     const { container } = render(
-      <AlbumGrid tiles={mockTiles} gridCols={6} gridRows={6} base={120} />,
+      <AlbumGrid tiles={mockTiles} gridCols={6} gridRows={6} tileSize={120} />,
     );
     const tiles = container.querySelectorAll('.album-grid__tile');
     expect(tiles).toHaveLength(2);
@@ -21,7 +21,7 @@ describe('AlbumGrid', () => {
   });
 
   it('returns null when tiles is empty', () => {
-    const { container } = render(<AlbumGrid tiles={[]} gridCols={6} gridRows={6} base={120} />);
+    const { container } = render(<AlbumGrid tiles={[]} gridCols={6} gridRows={6} tileSize={120} />);
     expect(container.innerHTML).toBe('');
   });
 });

--- a/packages/client/src/contexts/SpotifyContext.tsx
+++ b/packages/client/src/contexts/SpotifyContext.tsx
@@ -12,6 +12,18 @@ import type { NowPlaying, RelatedAlbums, SpotifyAlbum } from '../types';
 
 const CONNECTION_LOST_THRESHOLD = 3;
 
+const ActionType = {
+  FETCH_NOW_PLAYING_REQUEST: 'FETCH_NOW_PLAYING_REQUEST',
+  FETCH_NOW_PLAYING_SUCCESS: 'FETCH_NOW_PLAYING_SUCCESS',
+  FETCH_NOW_PLAYING_DUPE: 'FETCH_NOW_PLAYING_DUPE',
+  UPDATE_PROGRESS: 'UPDATE_PROGRESS',
+  FETCH_NOW_PLAYING_FAILURE: 'FETCH_NOW_PLAYING_FAILURE',
+  CLEAR_RELATED_ALBUMS: 'CLEAR_RELATED_ALBUMS',
+  FETCH_RELATED_ALBUMS_REQUEST: 'FETCH_RELATED_ALBUMS_REQUEST',
+  FETCH_RELATED_ALBUMS_SUCCESS: 'FETCH_RELATED_ALBUMS_SUCCESS',
+  FETCH_RELATED_ALBUMS_FAILURE: 'FETCH_RELATED_ALBUMS_FAILURE',
+} as const;
+
 interface SpotifyState {
   nowPlaying: NowPlaying | null;
   relatedAlbums: RelatedAlbums;
@@ -23,15 +35,15 @@ interface SpotifyState {
 }
 
 type SpotifyAction =
-  | { type: 'FETCH_NOW_PLAYING_REQUEST' }
-  | { type: 'FETCH_NOW_PLAYING_SUCCESS'; payload: NowPlaying }
-  | { type: 'FETCH_NOW_PLAYING_DUPE' }
-  | { type: 'UPDATE_PROGRESS'; payload: { progressMs: number; isPlaying: boolean } }
-  | { type: 'FETCH_NOW_PLAYING_FAILURE'; payload: unknown }
-  | { type: 'CLEAR_RELATED_ALBUMS' }
-  | { type: 'FETCH_RELATED_ALBUMS_REQUEST' }
-  | { type: 'FETCH_RELATED_ALBUMS_SUCCESS'; payload: SpotifyAlbum[] }
-  | { type: 'FETCH_RELATED_ALBUMS_FAILURE' };
+  | { type: typeof ActionType.FETCH_NOW_PLAYING_REQUEST }
+  | { type: typeof ActionType.FETCH_NOW_PLAYING_SUCCESS; payload: NowPlaying }
+  | { type: typeof ActionType.FETCH_NOW_PLAYING_DUPE }
+  | { type: typeof ActionType.UPDATE_PROGRESS; payload: { progressMs: number; isPlaying: boolean } }
+  | { type: typeof ActionType.FETCH_NOW_PLAYING_FAILURE; payload: unknown }
+  | { type: typeof ActionType.CLEAR_RELATED_ALBUMS }
+  | { type: typeof ActionType.FETCH_RELATED_ALBUMS_REQUEST }
+  | { type: typeof ActionType.FETCH_RELATED_ALBUMS_SUCCESS; payload: SpotifyAlbum[] }
+  | { type: typeof ActionType.FETCH_RELATED_ALBUMS_FAILURE };
 
 interface FetchNowPlayingResult {
   songId: string;
@@ -65,10 +77,10 @@ const initialState: SpotifyState = {
 
 function reducer(state: SpotifyState, action: SpotifyAction): SpotifyState {
   switch (action.type) {
-    case 'FETCH_NOW_PLAYING_REQUEST':
+    case ActionType.FETCH_NOW_PLAYING_REQUEST:
       return { ...state, loading: true };
 
-    case 'FETCH_NOW_PLAYING_SUCCESS':
+    case ActionType.FETCH_NOW_PLAYING_SUCCESS:
       return {
         ...state,
         initialized: true,
@@ -78,10 +90,10 @@ function reducer(state: SpotifyState, action: SpotifyAction): SpotifyState {
         nowPlaying: action.payload,
       };
 
-    case 'FETCH_NOW_PLAYING_DUPE':
+    case ActionType.FETCH_NOW_PLAYING_DUPE:
       return { ...state, initialized: true, loading: false };
 
-    case 'UPDATE_PROGRESS':
+    case ActionType.UPDATE_PROGRESS:
       if (!state.nowPlaying) return state;
       return {
         ...state,
@@ -92,7 +104,7 @@ function reducer(state: SpotifyState, action: SpotifyAction): SpotifyState {
         },
       };
 
-    case 'FETCH_NOW_PLAYING_FAILURE': {
+    case ActionType.FETCH_NOW_PLAYING_FAILURE: {
       const consecutiveErrors = Math.min(state.consecutiveErrors + 1, CONNECTION_LOST_THRESHOLD);
       if (
         state.consecutiveErrors === consecutiveErrors &&
@@ -110,16 +122,16 @@ function reducer(state: SpotifyState, action: SpotifyAction): SpotifyState {
       };
     }
 
-    case 'CLEAR_RELATED_ALBUMS':
+    case ActionType.CLEAR_RELATED_ALBUMS:
       return {
         ...state,
         relatedAlbums: { byAlbumId: {}, allAlbumIds: [] },
       };
 
-    case 'FETCH_RELATED_ALBUMS_REQUEST':
+    case ActionType.FETCH_RELATED_ALBUMS_REQUEST:
       return { ...state, albumsLoading: true };
 
-    case 'FETCH_RELATED_ALBUMS_SUCCESS': {
+    case ActionType.FETCH_RELATED_ALBUMS_SUCCESS: {
       const byAlbumId: Record<string, SpotifyAlbum> = {};
       const allAlbumIds: string[] = [];
       for (const album of action.payload) {
@@ -133,7 +145,7 @@ function reducer(state: SpotifyState, action: SpotifyAction): SpotifyState {
       };
     }
 
-    case 'FETCH_RELATED_ALBUMS_FAILURE':
+    case ActionType.FETCH_RELATED_ALBUMS_FAILURE:
       return { ...state, albumsLoading: false };
 
     default:
@@ -156,21 +168,21 @@ export function SpotifyProvider({ children }: SpotifyProviderProps) {
       if (loadingRef.current) return null;
       loadingRef.current = true;
 
-      dispatch({ type: 'FETCH_NOW_PLAYING_REQUEST' });
+      dispatch({ type: ActionType.FETCH_NOW_PLAYING_REQUEST });
 
       try {
         const data = await getPlaybackState();
         const item = data?.item;
 
         if (!item) {
-          dispatch({ type: 'FETCH_NOW_PLAYING_DUPE' });
+          dispatch({ type: ActionType.FETCH_NOW_PLAYING_DUPE });
           return null;
         }
 
         if (item.id === currentSongId) {
-          dispatch({ type: 'FETCH_NOW_PLAYING_DUPE' });
+          dispatch({ type: ActionType.FETCH_NOW_PLAYING_DUPE });
           dispatch({
-            type: 'UPDATE_PROGRESS',
+            type: ActionType.UPDATE_PROGRESS,
             payload: {
               progressMs: data.progress_ms ?? 0,
               isPlaying: data.is_playing ?? false,
@@ -179,7 +191,7 @@ export function SpotifyProvider({ children }: SpotifyProviderProps) {
           return { songId: item.id, albumId: item.album?.id };
         }
 
-        const info: NowPlaying = {
+        const nowPlayingResult: NowPlaying = {
           songId: item.id,
           songTitle: item.name,
           songArtists: item.artists,
@@ -194,10 +206,10 @@ export function SpotifyProvider({ children }: SpotifyProviderProps) {
           isPlaying: data.is_playing ?? false,
         };
 
-        dispatch({ type: 'FETCH_NOW_PLAYING_SUCCESS', payload: info });
-        return info;
+        dispatch({ type: ActionType.FETCH_NOW_PLAYING_SUCCESS, payload: nowPlayingResult });
+        return nowPlayingResult;
       } catch (err) {
-        dispatch({ type: 'FETCH_NOW_PLAYING_FAILURE', payload: err });
+        dispatch({ type: ActionType.FETCH_NOW_PLAYING_FAILURE, payload: err });
         return null;
       } finally {
         loadingRef.current = false;
@@ -207,17 +219,17 @@ export function SpotifyProvider({ children }: SpotifyProviderProps) {
   );
 
   const fetchRelatedAlbums = useCallback(async (songId: string): Promise<void> => {
-    dispatch({ type: 'FETCH_RELATED_ALBUMS_REQUEST' });
+    dispatch({ type: ActionType.FETCH_RELATED_ALBUMS_REQUEST });
     try {
       const data = await getRelatedAlbums(songId);
-      dispatch({ type: 'FETCH_RELATED_ALBUMS_SUCCESS', payload: data });
+      dispatch({ type: ActionType.FETCH_RELATED_ALBUMS_SUCCESS, payload: data });
     } catch {
-      dispatch({ type: 'FETCH_RELATED_ALBUMS_FAILURE' });
+      dispatch({ type: ActionType.FETCH_RELATED_ALBUMS_FAILURE });
     }
   }, []);
 
   const clearRelatedAlbums = useCallback((): void => {
-    dispatch({ type: 'CLEAR_RELATED_ALBUMS' });
+    dispatch({ type: ActionType.CLEAR_RELATED_ALBUMS });
   }, []);
 
   const connectionLost = state.consecutiveErrors >= CONNECTION_LOST_THRESHOLD;

--- a/packages/client/src/contexts/__tests__/UserContext.test.tsx
+++ b/packages/client/src/contexts/__tests__/UserContext.test.tsx
@@ -21,6 +21,20 @@ function TestConsumer() {
   );
 }
 
+function renderWithProvider() {
+  return render(
+    <UserProvider>
+      <TestConsumer />
+    </UserProvider>,
+  );
+}
+
+async function waitForLoaded() {
+  await waitFor(() => {
+    expect(screen.getByTestId('loading')).toHaveTextContent('false');
+  });
+}
+
 describe('UserContext', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -34,47 +48,29 @@ describe('UserContext', () => {
   it('fetches user on mount and provides profile', async () => {
     mockedApi.getAuthUser.mockResolvedValue({ spotifyId: 'user1' });
 
-    render(
-      <UserProvider>
-        <TestConsumer />
-      </UserProvider>,
-    );
+    renderWithProvider();
 
     expect(screen.getByTestId('loading')).toHaveTextContent('true');
 
-    await waitFor(() => {
-      expect(screen.getByTestId('loading')).toHaveTextContent('false');
-    });
+    await waitForLoaded();
     expect(screen.getByTestId('user')).toHaveTextContent('user1');
   });
 
   it('sets error when auth check fails', async () => {
     mockedApi.getAuthUser.mockRejectedValue({ message: 'Network error' });
 
-    render(
-      <UserProvider>
-        <TestConsumer />
-      </UserProvider>,
-    );
+    renderWithProvider();
 
-    await waitFor(() => {
-      expect(screen.getByTestId('loading')).toHaveTextContent('false');
-    });
+    await waitForLoaded();
     expect(screen.getByTestId('error')).toHaveTextContent('Network error');
   });
 
   it('login navigates to auth endpoint', async () => {
     mockedApi.getAuthUser.mockResolvedValue(null);
 
-    render(
-      <UserProvider>
-        <TestConsumer />
-      </UserProvider>,
-    );
+    renderWithProvider();
 
-    await waitFor(() => {
-      expect(screen.getByTestId('loading')).toHaveTextContent('false');
-    });
+    await waitForLoaded();
 
     await userEvent.click(screen.getByText('Login'));
     expect(window.location.assign).toHaveBeenCalledWith('/api/auth/spotify');
@@ -83,15 +79,9 @@ describe('UserContext', () => {
   it('logout navigates to logout endpoint', async () => {
     mockedApi.getAuthUser.mockResolvedValue({ spotifyId: 'user1' });
 
-    render(
-      <UserProvider>
-        <TestConsumer />
-      </UserProvider>,
-    );
+    renderWithProvider();
 
-    await waitFor(() => {
-      expect(screen.getByTestId('loading')).toHaveTextContent('false');
-    });
+    await waitForLoaded();
 
     await userEvent.click(screen.getByText('Logout'));
     expect(window.location.assign).toHaveBeenCalledWith('/api/auth/user/logout');

--- a/packages/client/src/hooks/useAlbumGrid.ts
+++ b/packages/client/src/hooks/useAlbumGrid.ts
@@ -1,7 +1,9 @@
 import { useMemo } from 'react';
 import type { RelatedAlbums, WindowSize, Album, AlbumGridResult } from '../types';
 
-const BASE = 100;
+const TILE_SIZE_PX = 100;
+const OVERSCAN_MULTIPLIER = 1.6;
+const OVERSCAN_EXTRA_BLOCKS = 1;
 
 interface TemplateSlot {
   col: number;
@@ -93,12 +95,12 @@ export default function useAlbumGrid(
     const { byAlbumId, allAlbumIds } = relatedAlbums;
 
     if (allAlbumIds.length === 0) {
-      return { tiles: [], gridCols: 0, gridRows: 0, base: BASE };
+      return { tiles: [], gridCols: 0, gridRows: 0, tileSize: TILE_SIZE_PX };
     }
 
-    const blockSize = TEMPLATE_SIZE * BASE;
-    const repsX = Math.ceil((width * 1.6) / blockSize) + 1;
-    const repsY = Math.ceil((height * 1.6) / blockSize) + 1;
+    const blockSize = TEMPLATE_SIZE * TILE_SIZE_PX;
+    const repsX = Math.ceil((width * OVERSCAN_MULTIPLIER) / blockSize) + OVERSCAN_EXTRA_BLOCKS;
+    const repsY = Math.ceil((height * OVERSCAN_MULTIPLIER) / blockSize) + OVERSCAN_EXTRA_BLOCKS;
 
     let albumCursor = 0;
     const tiles: Album[] = [];
@@ -132,7 +134,7 @@ export default function useAlbumGrid(
       tiles,
       gridCols: repsX * TEMPLATE_SIZE,
       gridRows: repsY * TEMPLATE_SIZE,
-      base: BASE,
+      tileSize: TILE_SIZE_PX,
     };
   }, [relatedAlbums, windowSize]);
 }

--- a/packages/client/src/hooks/useNowPlayingPoller.ts
+++ b/packages/client/src/hooks/useNowPlayingPoller.ts
@@ -12,16 +12,16 @@ export default function useNowPlayingPoller(): void {
 
   useEffect(() => {
     const poll = async (): Promise<void> => {
-      const info = await fetchNowPlaying(loadingRef, currentSongIdRef.current);
-      if (!info) return;
+      const nowPlayingResult = await fetchNowPlaying(loadingRef, currentSongIdRef.current);
+      if (!nowPlayingResult) return;
 
-      currentSongIdRef.current = info.songId;
+      currentSongIdRef.current = nowPlayingResult.songId;
 
-      if (currentAlbumIdRef.current !== info.albumId) {
-        currentAlbumIdRef.current = info.albumId;
+      if (currentAlbumIdRef.current !== nowPlayingResult.albumId) {
+        currentAlbumIdRef.current = nowPlayingResult.albumId;
         // Stale-while-revalidate: keep old albums visible while new ones load.
         // FETCH_RELATED_ALBUMS_SUCCESS replaces the state entirely.
-        fetchRelatedAlbums(info.songId);
+        fetchRelatedAlbums(nowPlayingResult.songId);
       }
     };
 

--- a/packages/client/src/hooks/useWindowSize.ts
+++ b/packages/client/src/hooks/useWindowSize.ts
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
 import type { WindowSize } from '../types';
 
+const RESIZE_DEBOUNCE_MS = 300;
+
 export default function useWindowSize(): WindowSize {
   const [size, setSize] = useState<WindowSize>({
     width: window.innerWidth,
@@ -13,7 +15,7 @@ export default function useWindowSize(): WindowSize {
       clearTimeout(timeoutId);
       timeoutId = setTimeout(() => {
         setSize({ width: window.innerWidth, height: window.innerHeight });
-      }, 300);
+      }, RESIZE_DEBOUNCE_MS);
     };
 
     window.addEventListener('resize', handleResize);

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -1,3 +1,31 @@
+:root {
+  /* Colors */
+  --color-spotify-green: #1db954;
+  --color-spotify-green-hover: #1ed760;
+  --color-bg-primary: #212121;
+  --color-bg-surface: #424242;
+  --color-text-primary: rgba(255, 255, 255, 0.87);
+  --color-text-secondary: rgba(255, 255, 255, 0.54);
+
+  /* Shadows */
+  --shadow-elevation-3:
+    0 3px 5px -1px rgba(0, 0, 0, 0.2), 0 6px 10px 0 rgba(0, 0, 0, 0.14),
+    0 1px 18px 0 rgba(0, 0, 0, 0.12);
+
+  /* Spacing */
+  --spacing-overlay-inset: 30px;
+  --spacing-overlay-inset-mobile: 15px;
+
+  /* Border radius */
+  --radius-sm: 4px;
+
+  /* Z-index layers */
+  --z-overlay-bg: 0;
+  --z-overlay-gradient: 50;
+  --z-overlay-chrome: 100;
+  --z-dropdown: 200;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -14,7 +42,7 @@ body {
   margin: 0;
   padding: 0;
   font-family: 'Source Sans Pro', sans-serif;
-  background-color: #212121;
+  background-color: var(--color-bg-primary);
   color: #fff;
 }
 
@@ -22,6 +50,40 @@ body {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+}
+
+.btn-primary {
+  display: inline-flex;
+  align-items: center;
+  padding: 10px 24px;
+  background-color: var(--color-spotify-green);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.btn-primary:hover {
+  background-color: var(--color-spotify-green-hover);
+}
+
+.icon-interactive {
+  color: var(--color-text-primary);
+}
+
+.icon-interactive:hover,
+.icon-interactive:focus-visible {
+  color: var(--color-text-secondary);
+}
+
+.focus-ring:focus-visible {
+  outline: 2px solid var(--color-spotify-green);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
 }
 
 @keyframes fadein {

--- a/packages/client/src/pages/ErrorPage.css
+++ b/packages/client/src/pages/ErrorPage.css
@@ -4,5 +4,4 @@
   flex-grow: 1;
   justify-content: center;
   align-items: center;
-  background-color: #212121;
 }

--- a/packages/client/src/pages/HomePage.css
+++ b/packages/client/src/pages/HomePage.css
@@ -4,7 +4,6 @@
   flex-grow: 1;
   justify-content: center;
   align-items: center;
-  background-color: #212121;
 }
 
 .home-page__logo {

--- a/packages/client/src/pages/VisualizationContent.css
+++ b/packages/client/src/pages/VisualizationContent.css
@@ -8,35 +8,30 @@
 
 .visualization__content {
   position: relative;
-  z-index: 0;
+  z-index: var(--z-overlay-bg);
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  background-color: #424242;
+  background-color: var(--color-bg-surface);
 }
 
 .visualization__github-icon {
   position: absolute;
-  left: 30px;
-  top: 35px;
-  z-index: 100;
-  color: rgba(255, 255, 255, 0.87);
-}
-
-.visualization__github-icon:hover {
-  color: rgba(255, 255, 255, 0.54);
+  left: var(--spacing-overlay-inset);
+  top: calc(var(--spacing-overlay-inset) + 5px);
+  z-index: var(--z-overlay-chrome);
 }
 
 .visualization__user-container {
   position: absolute;
-  top: 30px;
-  right: 30px;
-  z-index: 100;
+  top: var(--spacing-overlay-inset);
+  right: var(--spacing-overlay-inset);
+  z-index: var(--z-overlay-chrome);
   display: flex;
 }
 
 .visualization__loading {
-  z-index: 100;
+  z-index: var(--z-overlay-chrome);
   align-self: center;
   margin: auto 0;
 }
@@ -46,7 +41,7 @@
   flex-grow: 1;
   justify-content: center;
   align-items: center;
-  z-index: 100;
+  z-index: var(--z-overlay-chrome);
 }
 
 .visualization__error {
@@ -55,7 +50,7 @@
   flex-grow: 1;
   justify-content: center;
   align-items: center;
-  z-index: 100;
+  z-index: var(--z-overlay-chrome);
   gap: 16px;
 }
 
@@ -69,31 +64,13 @@
   color: rgba(255, 255, 255, 0.7);
 }
 
-.visualization__reconnect-btn {
-  padding: 10px 24px;
-  background-color: #1db954;
-  color: #fff;
-  border: none;
-  border-radius: 4px;
-  font-family: 'Source Sans Pro', sans-serif;
-  font-size: 0.875rem;
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.visualization__reconnect-btn:hover {
-  background-color: #1ed760;
-}
-
 .visualization__bottom-gradient {
   position: absolute;
   bottom: 0;
   left: 0;
   width: 100%;
   height: 150px;
-  z-index: 50;
+  z-index: var(--z-overlay-gradient);
   background: linear-gradient(
     to top,
     rgba(0, 0, 0, 0.9) 0%,
@@ -105,14 +82,15 @@
   animation: pulse-gradient 4s ease-in-out infinite alternate;
 }
 
+/* Breakpoint: 600px */
 @media (max-width: 600px) {
   .visualization__github-icon {
     display: none;
   }
 
   .visualization__user-container {
-    top: 15px;
-    right: 15px;
+    top: var(--spacing-overlay-inset-mobile);
+    right: var(--spacing-overlay-inset-mobile);
   }
 }
 

--- a/packages/client/src/pages/VisualizationContent.tsx
+++ b/packages/client/src/pages/VisualizationContent.tsx
@@ -28,7 +28,7 @@ export default function VisualizationContent() {
   const { nowPlaying, relatedAlbums, initialized, error, connectionLost } = useSpotify();
   const castSession = useCastSession();
   const windowSize = useWindowSize();
-  const { tiles, gridCols, gridRows, base } = useAlbumGrid(relatedAlbums, windowSize);
+  const { tiles, gridCols, gridRows, tileSize } = useAlbumGrid(relatedAlbums, windowSize);
   const dominantColor = useDominantColor(nowPlaying?.albumImageUrl);
   const [fullscreen, setFullscreen] = useState<boolean>(false);
 
@@ -81,7 +81,7 @@ export default function VisualizationContent() {
   const photo = user?.photos?.[0];
   const userImageUrl = typeof photo === 'string' ? photo : photo?.url || photo?.value;
   const isInitialLoad = !initialized;
-  const songPlaying = nowPlaying?.artistName && nowPlaying?.songTitle;
+  const isSongPlaying = nowPlaying?.artistName && nowPlaying?.songTitle;
   const hasError = !!error;
 
   return (
@@ -93,7 +93,7 @@ export default function VisualizationContent() {
       {!isInitialLoad && (
         <>
           {!fullscreen && (
-            <a href={REPO_URL} className="visualization__github-icon">
+            <a href={REPO_URL} className="visualization__github-icon icon-interactive">
               <FontAwesomeIcon icon={faGithub} size="1x" />
             </a>
           )}
@@ -114,7 +114,7 @@ export default function VisualizationContent() {
         </>
       )}
 
-      {!isInitialLoad && songPlaying && (
+      {!isInitialLoad && isSongPlaying && (
         <SongCard
           songId={nowPlaying.songId}
           artistName={nowPlaying.artistName}
@@ -130,29 +130,31 @@ export default function VisualizationContent() {
 
         {!isInitialLoad && (hasError || connectionLost) && (
           <div
-            className={`visualization__error${songPlaying ? ' visualization__error--overlay' : ''}`}
+            className={`visualization__error${isSongPlaying ? ' visualization__error--overlay' : ''}`}
           >
             <p>
-              {songPlaying ? 'Connection lost. Retrying…' : 'Session expired or connection failed.'}
+              {isSongPlaying
+                ? 'Connection lost. Retrying…'
+                : 'Session expired or connection failed.'}
             </p>
-            <button className="visualization__reconnect-btn" onClick={login}>
+            <button className="btn-primary" onClick={login}>
               Reconnect with Spotify
             </button>
           </div>
         )}
 
-        {!isInitialLoad && !hasError && !connectionLost && !songPlaying && (
+        {!isInitialLoad && !hasError && !connectionLost && !isSongPlaying && (
           <div className="visualization__empty">
             <p>No song playing. Play something.</p>
           </div>
         )}
 
-        {!isInitialLoad && songPlaying && (
-          <AlbumGrid tiles={tiles} gridCols={gridCols} gridRows={gridRows} base={base} />
+        {!isInitialLoad && isSongPlaying && (
+          <AlbumGrid tiles={tiles} gridCols={gridCols} gridRows={gridRows} tileSize={tileSize} />
         )}
       </div>
 
-      {!isInitialLoad && songPlaying && (
+      {!isInitialLoad && isSongPlaying && (
         <ProgressBar
           progressMs={nowPlaying.progressMs}
           durationMs={nowPlaying.durationMs}

--- a/packages/client/src/pages/__tests__/HomePage.test.tsx
+++ b/packages/client/src/pages/__tests__/HomePage.test.tsx
@@ -2,21 +2,13 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import HomePage from '../HomePage';
-import * as UserContext from '../../contexts/UserContext';
+import { mockUseUser } from '../../__tests__/helpers/mockUserContext';
 
 vi.mock('../../contexts/UserContext');
 
-const mockedUserContext = vi.mocked(UserContext, true);
-
 describe('HomePage', () => {
   it('shows loading screen while auth is pending', () => {
-    mockedUserContext.useUser.mockReturnValue({
-      user: null,
-      loading: true,
-      error: null,
-      login: vi.fn(),
-      logout: vi.fn(),
-    });
+    mockUseUser({ loading: true });
 
     render(
       <MemoryRouter>
@@ -28,13 +20,7 @@ describe('HomePage', () => {
   });
 
   it('shows login button when not authenticated', () => {
-    mockedUserContext.useUser.mockReturnValue({
-      user: null,
-      loading: false,
-      error: null,
-      login: vi.fn(),
-      logout: vi.fn(),
-    });
+    mockUseUser();
 
     render(
       <MemoryRouter>
@@ -46,13 +32,7 @@ describe('HomePage', () => {
   });
 
   it('shows error message when auth check fails', () => {
-    mockedUserContext.useUser.mockReturnValue({
-      user: null,
-      loading: false,
-      error: 'Unauthorized',
-      login: vi.fn(),
-      logout: vi.fn(),
-    });
+    mockUseUser({ error: 'Unauthorized' });
 
     render(
       <MemoryRouter>
@@ -65,13 +45,7 @@ describe('HomePage', () => {
   });
 
   it('redirects to visualization when authenticated', () => {
-    mockedUserContext.useUser.mockReturnValue({
-      user: { spotifyId: 'user1', displayName: 'Test' },
-      loading: false,
-      error: null,
-      login: vi.fn(),
-      logout: vi.fn(),
-    });
+    mockUseUser({ user: { spotifyId: 'user1', displayName: 'Test' } });
 
     const { container } = render(
       <MemoryRouter>

--- a/packages/client/src/types/ui.ts
+++ b/packages/client/src/types/ui.ts
@@ -16,7 +16,7 @@ export interface AlbumGridResult {
   tiles: Album[];
   gridCols: number;
   gridRows: number;
-  base: number;
+  tileSize: number;
 }
 
 export interface UserProfile {

--- a/packages/server/src/middleware/rateLimiter.ts
+++ b/packages/server/src/middleware/rateLimiter.ts
@@ -2,35 +2,31 @@ import rateLimit from 'express-rate-limit';
 import type { RequestHandler } from 'express';
 
 const isProduction = process.env.NODE_ENV === 'production';
+const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
 
 const passthrough: RequestHandler = (_req, _res, next) => next();
 
-export const apiLimiter: RequestHandler = isProduction
-  ? rateLimit({
-      windowMs: 15 * 60 * 1000,
-      max: 1000,
-      standardHeaders: true,
-      legacyHeaders: false,
-      message: 'Too many requests, please try again later.',
-    })
-  : passthrough;
+function createLimiter(max: number, message: string): RequestHandler {
+  return isProduction
+    ? rateLimit({
+        windowMs: RATE_LIMIT_WINDOW_MS,
+        max,
+        standardHeaders: true,
+        legacyHeaders: false,
+        message,
+      })
+    : passthrough;
+}
 
-export const authLimiter: RequestHandler = isProduction
-  ? rateLimit({
-      windowMs: 15 * 60 * 1000,
-      max: 50,
-      standardHeaders: true,
-      legacyHeaders: false,
-      message: 'Too many authentication requests, please try again later.',
-    })
-  : passthrough;
-
-export const spotifyLimiter: RequestHandler = isProduction
-  ? rateLimit({
-      windowMs: 15 * 60 * 1000,
-      max: 500,
-      standardHeaders: true,
-      legacyHeaders: false,
-      message: 'Too many requests, please try again later.',
-    })
-  : passthrough;
+export const apiLimiter: RequestHandler = createLimiter(
+  1000,
+  'Too many requests, please try again later.',
+);
+export const authLimiter: RequestHandler = createLimiter(
+  50,
+  'Too many authentication requests, please try again later.',
+);
+export const spotifyLimiter: RequestHandler = createLimiter(
+  500,
+  'Too many requests, please try again later.',
+);

--- a/packages/server/src/routes/spotify.ts
+++ b/packages/server/src/routes/spotify.ts
@@ -2,14 +2,8 @@ import { Router, type IRouter, Request, Response } from 'express';
 import { spotifyApiWithToken } from '../spotify/api/SpotifyApi';
 import apiRequestWithRefresh from '../spotify/api/helpers/apiRequestWithRefresh';
 import getCurrentlyPlayingRelatedAlbums from '../spotify/api/helpers/getCurrentlyPlayingRelatedAlbums';
+import errorMessage from '../utils/errorMessage';
 import type { SpotifyAlbum } from '../types';
-
-function errorMessage(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message;
-  }
-  return 'Unknown Error';
-}
 
 const router: IRouter = Router();
 

--- a/packages/server/src/spotify/api/helpers/apiRequestWithRefresh.ts
+++ b/packages/server/src/spotify/api/helpers/apiRequestWithRefresh.ts
@@ -11,8 +11,7 @@ async function getValidAccessToken(user: User | undefined): Promise<string> {
     throw new Error('Request has no user or access token');
   }
 
-  const requiresRefresh = tokenExpired(user.tokenUpdated, user.expiresIn);
-  if (!requiresRefresh) {
+  if (!tokenExpired(user.tokenUpdated, user.expiresIn)) {
     return user.spotifyAccessToken;
   }
 

--- a/packages/server/src/spotify/api/helpers/getRelatedArtists.ts
+++ b/packages/server/src/spotify/api/helpers/getRelatedArtists.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import logger from '../../../logger';
 import { relatedArtistsCache, normalizeKey } from '../../../cache';
+import errorMessage from '../../../utils/errorMessage';
 import type { LastFmResponse, ListenBrainzResponse, MusicBrainzResponse } from '../../../types';
 
 const LASTFM_BASE = 'https://ws.audioscrobbler.com/2.0/';
@@ -32,7 +33,7 @@ async function fromLastFm(artistName: string, limit = 30): Promise<string[]> {
     logger.info(`Last.fm: ${names.length} similar artists for "${artistName}"`);
     return names;
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
+    const message = errorMessage(error);
     logger.warn(`Last.fm failed for "${artistName}": ${message}`);
     return [];
   }
@@ -77,7 +78,7 @@ async function fromListenBrainz(artistName: string, limit = 20): Promise<string[
     logger.info(`ListenBrainz: ${names.length} similar artists for "${artistName}"`);
     return names;
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
+    const message = errorMessage(error);
     logger.warn(`ListenBrainz failed for "${artistName}": ${message}`);
     return [];
   }

--- a/packages/server/src/spotify/api/helpers/getRelatedArtists.ts
+++ b/packages/server/src/spotify/api/helpers/getRelatedArtists.ts
@@ -33,8 +33,7 @@ async function fromLastFm(artistName: string, limit = 30): Promise<string[]> {
     logger.info(`Last.fm: ${names.length} similar artists for "${artistName}"`);
     return names;
   } catch (error) {
-    const message = errorMessage(error);
-    logger.warn(`Last.fm failed for "${artistName}": ${message}`);
+    logger.warn(`Last.fm failed for "${artistName}": ${errorMessage(error)}`);
     return [];
   }
 }
@@ -78,8 +77,7 @@ async function fromListenBrainz(artistName: string, limit = 20): Promise<string[
     logger.info(`ListenBrainz: ${names.length} similar artists for "${artistName}"`);
     return names;
   } catch (error) {
-    const message = errorMessage(error);
-    logger.warn(`ListenBrainz failed for "${artistName}": ${message}`);
+    logger.warn(`ListenBrainz failed for "${artistName}": ${errorMessage(error)}`);
     return [];
   }
 }

--- a/packages/server/src/spotify/utils/uniqueAlbums.ts
+++ b/packages/server/src/spotify/utils/uniqueAlbums.ts
@@ -24,9 +24,7 @@ const suffixRegexp = new RegExp(`${openingBrace}(${joinedTypesWithSuffixes})${cl
 // Filters out some common suffixes that results in duplicate
 // album covers, such as special and deluxe edition albums.
 export function baseAlbumName(albumName: string): string {
-  const strippedAlbumName = albumName.replace(suffixRegexp, '');
-  // Ensures all whitespace between base album name and suffix is removed.
-  return strippedAlbumName.trim();
+  return albumName.replace(suffixRegexp, '').trim();
 }
 
 export default function uniqueAlbums(albums: SpotifyAlbum[]): SpotifyAlbum[] {

--- a/packages/server/src/utils/errorMessage.ts
+++ b/packages/server/src/utils/errorMessage.ts
@@ -1,6 +1,3 @@
 export default function errorMessage(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message;
-  }
-  return 'Unknown error';
+  return error instanceof Error ? error.message : 'Unknown error';
 }

--- a/packages/server/src/utils/errorMessage.ts
+++ b/packages/server/src/utils/errorMessage.ts
@@ -1,0 +1,6 @@
+export default function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return 'Unknown error';
+}


### PR DESCRIPTION
## Summary

- Extract repeated CSS values (colors, spacing, z-index, shadows, border-radius) into `:root` custom properties as design tokens
- Add shared utility classes (`.btn-primary`, `.icon-interactive`, `.focus-ring`) to eliminate duplicated button, icon hover, and focus ring styles
- Name all magic numbers with descriptive constants (`TILE_SIZE_PX`, `CASCADE_FLIP_STAGGER_MS`, `SONG_CARD_FADE_MS`, `RESIZE_DEBOUNCE_MS`, etc.)
- Replace string literal action types in `SpotifyContext` with `ActionType` const object
- Improve variable naming: `BASE` → `TILE_SIZE_PX`, `imagePoolRef` → `imageIndexRef`, `info` → `nowPlayingResult`, `songPlaying` → `isSongPlaying`
- Deduplicate rate limiter config via `createLimiter()` factory, extract shared `errorMessage()` utility, and create `mockUseUser()` test helper
- Remove redundant `background-color` and `font-family` declarations inherited from `body`
- Document code quality conventions in `CONTRIBUTING.md`

CSS bundle size reduced from 9.62kB → 8.96kB (−7%).

## Test plan

- [x] `pnpm format:check` passes
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm client:test` — 21 tests pass
- [x] `pnpm server:test` — 49 tests pass
- [x] `pnpm client:build` succeeds
- [x] Server and client type checks pass
- [ ] Manual: verify visualization page renders correctly (grid, song card, tiles, colors, hover states)

🤖 Generated with [Claude Code](https://claude.com/claude-code)