### PR TITLE
feat: add pre-commit hook for formatting and lint checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,16 @@ This runs formatting, linting, tests, build, and type-checking for both packages
 - **Rate limiters** — Use `createLimiter(max, message)` in `rateLimiter.ts` to add new limiters.
 - **Test mocks** — Use `mockUseUser()` from `packages/client/src/__tests__/helpers/mockUserContext.ts` instead of repeating the full mock shape. Only pass overrides for what your test cares about.
 
+## Git Hooks
+
+Install the pre-commit hook to catch formatting and lint issues before they reach CI:
+
+```bash
+./scripts/install-hooks.sh
+```
+
+The hook runs Prettier and ESLint on staged files only, so it's fast. It does not run tests or type checks — those are covered by `pre-pr.sh` and CI.
+
 Individual checks:
 
 ```bash

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+HOOK_DIR="$(git rev-parse --git-common-dir)/hooks"
+mkdir -p "$HOOK_DIR"
+
+cp scripts/pre-commit "$HOOK_DIR/pre-commit"
+chmod +x "$HOOK_DIR/pre-commit"
+echo "Installed pre-commit hook to $HOOK_DIR/pre-commit"

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -e
+
+STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
+
+if [ -z "$STAGED" ]; then
+  exit 0
+fi
+
+# Format check — only staged files
+echo "$STAGED" | xargs pnpm prettier --check
+
+# Lint — only staged .ts/.tsx/.js/.jsx files, split by package
+CLIENT_FILES=$(echo "$STAGED" | grep '^packages/client/src/.*\.\(ts\|tsx\|js\|jsx\)$' || true)
+SERVER_FILES=$(echo "$STAGED" | grep '^packages/server/src/.*\.\(ts\|tsx\|js\|jsx\)$' || true)
+
+if [ -n "$CLIENT_FILES" ]; then
+  echo "$CLIENT_FILES" | xargs pnpm --filter spune-client exec eslint
+fi
+
+if [ -n "$SERVER_FILES" ]; then
+  echo "$SERVER_FILES" | xargs pnpm --filter spune-server exec eslint
+fi


### PR DESCRIPTION
## Summary
- Adds a pre-commit hook (`scripts/pre-commit`) that runs Prettier and ESLint on staged files only — no new dependencies
- Adds `scripts/install-hooks.sh` to install the hook (handles git worktrees)
- Documents the hook in CONTRIBUTING.md

## Test plan
- [ ] Run `./scripts/install-hooks.sh` and verify hook installs
- [ ] Stage a file with formatting issues and verify commit is blocked
- [ ] Stage a clean file and verify commit succeeds
- [ ] CI passes (format, lint, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)