### PR TITLE
fix: stop polling after 30s of failures, render error above gradient

### DIFF
--- a/packages/client/src/hooks/useNowPlayingPoller.ts
+++ b/packages/client/src/hooks/useNowPlayingPoller.ts
@@ -37,9 +37,9 @@ export default function useNowPlayingPoller(): void {
     }
   }, [sse.connected, sse.nowPlaying, dispatch, fetchRelatedAlbums]);
 
-  // Polling fallback: only active when SSE is not connected
+  // Polling fallback: only active when SSE is not connected and hasn't given up
   useEffect(() => {
-    if (sse.connected) return; // SSE is handling updates
+    if (sse.connected || sse.gaveUp) return;
 
     const poll = async (): Promise<void> => {
       const nowPlayingResult = await fetchNowPlaying(loadingRef, currentSongIdRef.current);
@@ -56,5 +56,5 @@ export default function useNowPlayingPoller(): void {
     poll();
     const id = setInterval(poll, POLL_INTERVAL);
     return () => clearInterval(id);
-  }, [sse.connected, fetchNowPlaying, fetchRelatedAlbums]);
+  }, [sse.connected, sse.gaveUp, fetchNowPlaying, fetchRelatedAlbums]);
 }

--- a/packages/client/src/hooks/usePlaybackSSE.ts
+++ b/packages/client/src/hooks/usePlaybackSSE.ts
@@ -19,8 +19,12 @@ interface SSEPlaybackEvent {
   song_changed: boolean;
 }
 
+const RECONNECT_DELAY = 5000;
+const GIVE_UP_THRESHOLD = 30000;
+
 interface UsePlaybackSSEResult {
   connected: boolean;
+  gaveUp: boolean;
   nowPlaying: NowPlaying | null;
   songChanged: boolean;
   progressMs: number;
@@ -29,12 +33,14 @@ interface UsePlaybackSSEResult {
 
 export default function usePlaybackSSE(): UsePlaybackSSEResult {
   const [connected, setConnected] = useState(false);
+  const [gaveUp, setGaveUp] = useState(false);
   const [nowPlaying, setNowPlaying] = useState<NowPlaying | null>(null);
   const [songChanged, setSongChanged] = useState(false);
   const [progressMs, setProgressMs] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
   const eventSourceRef = useRef<EventSource | null>(null);
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const firstErrorAtRef = useRef<number | null>(null);
 
   const connect = useCallback(() => {
     if (eventSourceRef.current) {
@@ -46,6 +52,8 @@ export default function usePlaybackSSE(): UsePlaybackSSEResult {
 
     es.onopen = () => {
       setConnected(true);
+      setGaveUp(false);
+      firstErrorAtRef.current = null;
     };
 
     es.addEventListener('playback', (event: MessageEvent) => {
@@ -96,8 +104,17 @@ export default function usePlaybackSSE(): UsePlaybackSSEResult {
       es.close();
       eventSourceRef.current = null;
 
-      // Reconnect after 5 seconds
-      reconnectTimeoutRef.current = setTimeout(connect, 5000);
+      const now = Date.now();
+      if (firstErrorAtRef.current === null) {
+        firstErrorAtRef.current = now;
+      }
+
+      if (now - firstErrorAtRef.current >= GIVE_UP_THRESHOLD) {
+        setGaveUp(true);
+        return;
+      }
+
+      reconnectTimeoutRef.current = setTimeout(connect, RECONNECT_DELAY);
     };
   }, []);
 
@@ -114,5 +131,5 @@ export default function usePlaybackSSE(): UsePlaybackSSEResult {
     };
   }, [connect]);
 
-  return { connected, nowPlaying, songChanged, progressMs, isPlaying };
+  return { connected, gaveUp, nowPlaying, songChanged, progressMs, isPlaying };
 }

--- a/packages/client/src/pages/VisualizationContent.css
+++ b/packages/client/src/pages/VisualizationContent.css
@@ -45,9 +45,10 @@
 }
 
 .visualization__error {
+  position: absolute;
+  inset: 0;
   display: flex;
   flex-direction: column;
-  flex-grow: 1;
   justify-content: center;
   align-items: center;
   z-index: var(--z-overlay-chrome);
@@ -55,8 +56,6 @@
 }
 
 .visualization__error--overlay {
-  position: absolute;
-  inset: 0;
   background-color: rgba(0, 0, 0, 0.75);
 }
 

--- a/packages/client/src/pages/VisualizationContent.tsx
+++ b/packages/client/src/pages/VisualizationContent.tsx
@@ -144,9 +144,7 @@ export default function VisualizationContent() {
           className={`visualization__error${isSongPlaying ? ' visualization__error--overlay' : ''}`}
         >
           <p>
-            {isSongPlaying
-              ? 'Connection lost. Retrying…'
-              : 'Session expired or connection failed.'}
+            {isSongPlaying ? 'Connection lost. Retrying…' : 'Session expired or connection failed.'}
           </p>
           <button className="btn-primary" onClick={login}>
             Reconnect with Spotify

--- a/packages/client/src/pages/VisualizationContent.tsx
+++ b/packages/client/src/pages/VisualizationContent.tsx
@@ -128,21 +128,6 @@ export default function VisualizationContent() {
       <div className="visualization__content">
         {isInitialLoad && <LoadingScreen className="visualization__loading" />}
 
-        {!isInitialLoad && (hasError || connectionLost) && (
-          <div
-            className={`visualization__error${isSongPlaying ? ' visualization__error--overlay' : ''}`}
-          >
-            <p>
-              {isSongPlaying
-                ? 'Connection lost. Retrying…'
-                : 'Session expired or connection failed.'}
-            </p>
-            <button className="btn-primary" onClick={login}>
-              Reconnect with Spotify
-            </button>
-          </div>
-        )}
-
         {!isInitialLoad && !hasError && !connectionLost && !isSongPlaying && (
           <div className="visualization__empty">
             <p>No song playing. Play something.</p>
@@ -153,6 +138,21 @@ export default function VisualizationContent() {
           <AlbumGrid tiles={tiles} gridCols={gridCols} gridRows={gridRows} tileSize={tileSize} />
         )}
       </div>
+
+      {!isInitialLoad && (hasError || connectionLost) && (
+        <div
+          className={`visualization__error${isSongPlaying ? ' visualization__error--overlay' : ''}`}
+        >
+          <p>
+            {isSongPlaying
+              ? 'Connection lost. Retrying…'
+              : 'Session expired or connection failed.'}
+          </p>
+          <button className="btn-primary" onClick={login}>
+            Reconnect with Spotify
+          </button>
+        </div>
+      )}
 
       {!isInitialLoad && isSongPlaying && (
         <ProgressBar


### PR DESCRIPTION
## Summary
- SSE reconnection now gives up after 30s of continuous failures, stopping both reconnect attempts and the polling fallback
- Error overlay moved outside `.visualization__content` stacking context (z-index: 0) so it renders above the bottom gradient (z-index: 50) instead of appearing faded underneath it

## Test plan
- [ ] Disconnect network — verify error message appears clearly above the gradient, not faded
- [ ] Keep network disconnected for 30s+ — verify polling stops (no more requests in Network tab)
- [ ] Reconnect network and click "Reconnect with Spotify" — verify app recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)