### PR TITLE
fix: cast receiver layout and background entrance animation

### DIFF
--- a/packages/client/src/cast/receiver/ReceiverApp.tsx
+++ b/packages/client/src/cast/receiver/ReceiverApp.tsx
@@ -12,6 +12,7 @@ import type { RelatedAlbums, SpotifyAlbum } from '../../types';
 import { CAST_NAMESPACE } from '../types';
 import '../../index.css';
 import '../../App.css';
+import '../../pages/VisualizationContent.css';
 
 function buildRelatedAlbums(imageUrls: string[]): RelatedAlbums {
   const byAlbumId: Record<string, SpotifyAlbum> = {};
@@ -47,7 +48,9 @@ export default function ReceiverApp() {
   const handleMessage = useCallback((event: cast.framework.system.Event) => {
     try {
       const messageEvent = event as cast.framework.system.MessageEvent;
-      const data = JSON.parse(messageEvent.data as string) as CastMessage;
+      // CAF v3 automatically deserializes JSON strings, so data is already an object
+      const raw = messageEvent.data;
+      const data = (typeof raw === 'string' ? JSON.parse(raw) : raw) as CastMessage;
 
       if (data.type === 'UPDATE_PLAYBACK') {
         setNowPlaying(data.nowPlaying);
@@ -90,15 +93,7 @@ export default function ReceiverApp() {
   return (
     <div className="app">
       <div className="app__content">
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            flexGrow: 1,
-            overflow: 'hidden',
-            position: 'relative',
-          }}
-        >
+        <div className="visualization">
           <CoverOverlay dominantColor={dominantColor} />
 
           {songPlaying && (
@@ -112,31 +107,12 @@ export default function ReceiverApp() {
             />
           )}
 
-          <div
-            style={{
-              position: 'relative',
-              zIndex: 0,
-              display: 'flex',
-              flexDirection: 'column',
-              flexGrow: 1,
-              backgroundColor: '#424242',
-            }}
-          >
-            {!connected && !songPlaying && (
-              <div
-                style={{
-                  display: 'flex',
-                  flexGrow: 1,
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  flexDirection: 'column',
-                  gap: '12px',
-                }}
-              >
-                <LoadingScreen />
-                <p style={{ color: 'rgba(255,255,255,0.5)', fontSize: '0.9rem' }}>
-                  Waiting for cast connection...
-                </p>
+          <div className="visualization__content">
+            {!connected && !songPlaying && <LoadingScreen className="visualization__loading" />}
+
+            {connected && !songPlaying && (
+              <div className="visualization__empty">
+                <p>Waiting for playback data...</p>
               </div>
             )}
 
@@ -157,6 +133,8 @@ export default function ReceiverApp() {
               isPlaying={nowPlaying.isPlaying}
             />
           )}
+
+          <div className="visualization__bottom-gradient" />
         </div>
       </div>
     </div>

--- a/packages/client/src/components/CoverOverlay.css
+++ b/packages/client/src/components/CoverOverlay.css
@@ -26,7 +26,20 @@
   );
   opacity: 0.6;
   background-size: 1200% 1200%;
-  animation: move-background 360s ease infinite alternate;
+  animation:
+    gradient-entrance 2s ease-out forwards,
+    move-background 360s ease infinite alternate;
+}
+
+@keyframes gradient-entrance {
+  from {
+    opacity: 0;
+    transform: scale(1.15);
+  }
+  to {
+    opacity: 0.6;
+    transform: scale(1);
+  }
 }
 
 .cover-overlay__color {
@@ -46,4 +59,14 @@
     rgba(0, 0, 0, 0.75) 75%,
     rgba(0, 0, 0, 1) 100%
   );
+  animation: darken-entrance 2s ease-out forwards;
+}
+
+@keyframes darken-entrance {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }

--- a/packages/client/src/pages/VisualizationContent.css
+++ b/packages/client/src/pages/VisualizationContent.css
@@ -12,7 +12,7 @@
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  background-color: var(--color-bg-surface);
+  background-color: transparent;
 }
 
 .visualization__github-icon {


### PR DESCRIPTION
## Summary
- Fix Chromecast receiver showing only gradient by handling CAF v3 auto-deserialized message data
- Replace inline styles with shared `visualization` CSS classes so the receiver matches the web layout (minus interactive controls)
- Add fade-in + zoom entrance animation on the background gradient at page load
- Make visualization content background transparent so the gradient shows through during loading

## Test plan
- [ ] Deploy and verify Chromecast receiver renders album grid, song card, and progress bar
- [ ] Verify web app background animates in on page load
- [ ] Verify loading/empty states display correctly on both web and receiver

🤖 Generated with [Claude Code](https://claude.com/claude-code)