### PR TITLE
feat: mobile layout improvements and deploy status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,3 +148,16 @@ jobs:
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            COMMIT_SHA=${{ github.sha }}
+
+  deploy-check:
+    runs-on: ubuntu-latest
+    needs: [docker]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Wait for deployment
+        run: ./scripts/check-deploy.sh https://spune.tinney.dev/api/status "${{ github.sha }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,10 @@ COPY packages/server/ packages/server/
 ARG VITE_CAST_APP_ID=CCD3A879
 ENV VITE_CAST_APP_ID=$VITE_CAST_APP_ID
 
+# Commit SHA for /api/status endpoint
+ARG COMMIT_SHA=unknown
+RUN echo "$COMMIT_SHA" > packages/server/COMMIT_SHA
+
 # Build the client and compile the server TypeScript
 RUN pnpm client:build && pnpm server:build
 
@@ -39,8 +43,9 @@ COPY packages/server/package.json packages/server/
 # Install production server dependencies only
 RUN pnpm install --frozen-lockfile --filter spune-server --prod
 
-# Copy compiled server from build stage
+# Copy compiled server and version file from build stage
 COPY --from=build /app/packages/server/dist packages/server/dist/
+COPY --from=build /app/packages/server/COMMIT_SHA packages/server/COMMIT_SHA
 
 # Copy built client from build stage
 COPY --from=build /app/packages/client/build packages/client/build/

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Spune can cast the visualization to a Chromecast-enabled TV. See [docs/chromecas
 
 ## Production Deployment
 
-CI auto-builds and pushes a Docker image to `ghcr.io` on every merge to `master`. See [docs/deployment.md](docs/deployment.md).
+CI auto-builds and pushes a Docker image to `ghcr.io` on every merge to `master`. After push, a deploy-check job polls `GET /api/status` until the droplet is running the new version. See [docs/deployment.md](docs/deployment.md).
 
 **Quick version**:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -57,6 +57,34 @@ Add `https://your-domain.com/api/auth/spotify/callback` to your Spotify app's re
 3. Watchtower detects the new image within 60 seconds
 4. It pulls and restarts the app container
 
+### Deploy verification
+
+CI includes a `deploy-check` job that polls `GET /api/status` after the Docker image is pushed, waiting for the running version to match the new commit SHA.
+
+You can also run the check manually:
+
+```bash
+./scripts/check-deploy.sh https://spune.tinney.dev/api/status <commit-sha>
+```
+
+### Status endpoint
+
+`GET /api/status` returns:
+
+```json
+{
+  "version": "abc1234...",
+  "uptime": 12345.67,
+  "startedAt": "2025-01-01T00:00:00.000Z"
+}
+```
+
+- **version**: The commit SHA baked into the Docker image at build time
+- **uptime**: Seconds since the Node.js process started
+- **startedAt**: ISO timestamp of when the process started
+
+Rate-limited to 30 requests per 15 minutes.
+
 ## Debugging
 
 ```bash

--- a/packages/client/src/cast/sender/CastButton.css
+++ b/packages/client/src/cast/sender/CastButton.css
@@ -31,3 +31,11 @@
   outline-offset: 2px;
   border-radius: 4px;
 }
+
+/* Breakpoint: 600px */
+@media (max-width: 600px) {
+  .cast-button {
+    right: var(--spacing-overlay-inset-mobile);
+    bottom: var(--spacing-overlay-inset-mobile);
+  }
+}

--- a/packages/client/src/components/FullscreenButton.css
+++ b/packages/client/src/components/FullscreenButton.css
@@ -8,3 +8,10 @@
   border: none;
   padding: 8px;
 }
+
+/* Breakpoint: 600px */
+@media (max-width: 600px) {
+  .fullscreen-button {
+    display: none;
+  }
+}

--- a/packages/client/src/components/ProgressBar.css
+++ b/packages/client/src/components/ProgressBar.css
@@ -39,3 +39,14 @@
   border-radius: 1px;
   transition: width 0.3s linear;
 }
+
+/* Breakpoint: 600px */
+@media (max-width: 600px) {
+  .progress-bar {
+    left: var(--spacing-overlay-inset-mobile);
+    transform: none;
+    bottom: var(--spacing-overlay-inset-mobile);
+    max-width: 200px;
+    padding: 0;
+  }
+}

--- a/packages/client/src/components/SongCard.css
+++ b/packages/client/src/components/SongCard.css
@@ -62,7 +62,7 @@
 @media (max-width: 600px) {
   .song-card {
     left: var(--spacing-overlay-inset-mobile);
-    bottom: var(--spacing-overlay-inset-mobile);
+    bottom: 40px;
   }
 
   .song-card__cover {

--- a/packages/client/src/hooks/useAlbumGrid.ts
+++ b/packages/client/src/hooks/useAlbumGrid.ts
@@ -2,6 +2,8 @@ import { useMemo } from 'react';
 import type { RelatedAlbums, WindowSize, Album, AlbumGridResult } from '../types';
 
 const TILE_SIZE_PX = 100;
+const TILE_SIZE_MOBILE_PX = 70;
+const MOBILE_BREAKPOINT = 600;
 const OVERSCAN_MULTIPLIER = 1.6;
 const OVERSCAN_EXTRA_BLOCKS = 1;
 
@@ -93,12 +95,13 @@ export default function useAlbumGrid(
   return useMemo(() => {
     const { width, height } = windowSize;
     const { byAlbumId, allAlbumIds } = relatedAlbums;
+    const tileSize = width <= MOBILE_BREAKPOINT ? TILE_SIZE_MOBILE_PX : TILE_SIZE_PX;
 
     if (allAlbumIds.length === 0) {
-      return { tiles: [], gridCols: 0, gridRows: 0, tileSize: TILE_SIZE_PX };
+      return { tiles: [], gridCols: 0, gridRows: 0, tileSize };
     }
 
-    const blockSize = TEMPLATE_SIZE * TILE_SIZE_PX;
+    const blockSize = TEMPLATE_SIZE * tileSize;
     const repsX = Math.ceil((width * OVERSCAN_MULTIPLIER) / blockSize) + OVERSCAN_EXTRA_BLOCKS;
     const repsY = Math.ceil((height * OVERSCAN_MULTIPLIER) / blockSize) + OVERSCAN_EXTRA_BLOCKS;
 
@@ -134,7 +137,7 @@ export default function useAlbumGrid(
       tiles,
       gridCols: repsX * TEMPLATE_SIZE,
       gridRows: repsY * TEMPLATE_SIZE,
-      tileSize: TILE_SIZE_PX,
+      tileSize,
     };
   }, [relatedAlbums, windowSize]);
 }

--- a/packages/server/src/middleware/rateLimiter.ts
+++ b/packages/server/src/middleware/rateLimiter.ts
@@ -2,31 +2,24 @@ import rateLimit from 'express-rate-limit';
 import type { RequestHandler } from 'express';
 
 const isProduction = process.env.NODE_ENV === 'production';
+// 15 minutes
 const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
 
 const passthrough: RequestHandler = (_req, _res, next) => next();
 
-function createLimiter(max: number, message: string): RequestHandler {
+function createLimiter(max: number): RequestHandler {
   return isProduction
     ? rateLimit({
         windowMs: RATE_LIMIT_WINDOW_MS,
         max,
         standardHeaders: true,
         legacyHeaders: false,
-        message,
+        message: 'Too many requests, please try again later.',
       })
     : passthrough;
 }
 
-export const apiLimiter: RequestHandler = createLimiter(
-  1000,
-  'Too many requests, please try again later.',
-);
-export const authLimiter: RequestHandler = createLimiter(
-  50,
-  'Too many authentication requests, please try again later.',
-);
-export const spotifyLimiter: RequestHandler = createLimiter(
-  500,
-  'Too many requests, please try again later.',
-);
+export const apiLimiter: RequestHandler = createLimiter(1000);
+export const authLimiter: RequestHandler = createLimiter(50);
+export const spotifyLimiter: RequestHandler = createLimiter(500);
+export const statusLimiter: RequestHandler = createLimiter(30);

--- a/packages/server/src/routes/__tests__/status.test.ts
+++ b/packages/server/src/routes/__tests__/status.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import createApp from '../../createApp';
+
+const app = createApp();
+
+describe('/status', () => {
+  it('returns version, uptime, and startedAt', async () => {
+    const response = await request(app).get('/api/status');
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toHaveProperty('version');
+    expect(response.body).toHaveProperty('uptime');
+    expect(response.body).toHaveProperty('startedAt');
+    expect(typeof response.body.uptime).toBe('number');
+  });
+});

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -1,8 +1,9 @@
 import { Router, type IRouter } from 'express';
-import { apiLimiter, authLimiter, spotifyLimiter } from '../middleware/rateLimiter';
+import { apiLimiter, authLimiter, spotifyLimiter, statusLimiter } from '../middleware/rateLimiter';
 import authRoutes from './auth';
 import spotifyRoutes from './spotify';
 import sseRoutes from './sse';
+import statusRoutes from './status';
 
 const router: IRouter = Router();
 
@@ -13,5 +14,6 @@ router.use(apiLimiter);
 router.use('/auth', authLimiter, authRoutes);
 router.use('/spotify', spotifyLimiter, spotifyRoutes);
 router.use('/sse', sseRoutes); // No rate limiting — long-lived connections
+router.use('/status', statusLimiter, statusRoutes);
 
 export default router;

--- a/packages/server/src/routes/status.ts
+++ b/packages/server/src/routes/status.ts
@@ -1,0 +1,24 @@
+import { Router, type IRouter } from 'express';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const router: IRouter = Router();
+
+let commitSha = 'unknown';
+try {
+  commitSha = readFileSync(resolve(__dirname, '../../COMMIT_SHA'), 'utf-8').trim();
+} catch {
+  // Not available outside Docker builds — default to 'unknown'
+}
+
+const startedAt = new Date().toISOString();
+
+router.get('/', (_req, res) => {
+  res.json({
+    version: commitSha,
+    uptime: process.uptime(),
+    startedAt,
+  });
+});
+
+export default router;

--- a/scripts/check-deploy.sh
+++ b/scripts/check-deploy.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Poll /api/status until the deployed version matches the expected commit SHA.
+#
+# Usage:
+#   ./scripts/check-deploy.sh <status-url> <expected-sha>
+#
+# Example:
+#   ./scripts/check-deploy.sh https://spune.example.com/api/status abc123def456
+#
+# Exits 0 on success, 1 on timeout (5 minutes).
+set -euo pipefail
+
+STATUS_URL="${1:-${STATUS_URL:-}}"
+EXPECTED_SHA="${2:-${EXPECTED_SHA:-}}"
+
+if [ -z "$STATUS_URL" ]; then
+  echo "Usage: $0 <status-url> <expected-sha>"
+  echo "  Or set STATUS_URL and EXPECTED_SHA environment variables."
+  exit 1
+fi
+
+if [ -z "$EXPECTED_SHA" ]; then
+  echo "Error: expected SHA not provided."
+  exit 1
+fi
+
+MAX_ATTEMPTS=30
+INTERVAL=10
+
+echo "Waiting for $STATUS_URL to report version $EXPECTED_SHA"
+
+for i in $(seq 1 "$MAX_ATTEMPTS"); do
+  VERSION=$(curl -sf "$STATUS_URL" | jq -r '.version // empty' 2>/dev/null || true)
+  if [ "$VERSION" = "$EXPECTED_SHA" ]; then
+    echo "Deployed successfully (attempt $i)"
+    exit 0
+  fi
+  echo "Attempt $i/$MAX_ATTEMPTS: got '${VERSION:-<no response>}', waiting ${INTERVAL}s..."
+  sleep "$INTERVAL"
+done
+
+echo "Timed out waiting for deployment after $((MAX_ATTEMPTS * INTERVAL)) seconds"
+exit 1


### PR DESCRIPTION
## Summary
- Improve mobile layout (600px breakpoint): smaller tiles, repositioned progress bar/cast button/song card, hidden fullscreen button
- Add `GET /api/status` endpoint returning commit SHA, uptime, and start time (rate-limited to 30 req/15min)
- Add `deploy-check` CI job that polls the status endpoint after Docker push until the new version is live
- Extract deploy polling to `scripts/check-deploy.sh` for manual use

## Test plan
- [ ] Verify mobile layout on phone — no overlapping controls
- [ ] Verify desktop layout is unchanged
- [ ] Verify cast receiver layout is unchanged
- [ ] Verify `GET /api/status` returns expected JSON after deploy
- [ ] Verify `deploy-check` CI job passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)