### PR TITLE
fix: use env var for commit SHA in /api/status

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,6 @@ COPY packages/server/ packages/server/
 ARG VITE_CAST_APP_ID=CCD3A879
 ENV VITE_CAST_APP_ID=$VITE_CAST_APP_ID
 
-# Commit SHA for /api/status endpoint
-ARG COMMIT_SHA=unknown
-RUN echo "$COMMIT_SHA" > packages/server/COMMIT_SHA
-
 # Build the client and compile the server TypeScript
 RUN pnpm client:build && pnpm server:build
 
@@ -43,9 +39,8 @@ COPY packages/server/package.json packages/server/
 # Install production server dependencies only
 RUN pnpm install --frozen-lockfile --filter spune-server --prod
 
-# Copy compiled server and version file from build stage
+# Copy compiled server from build stage
 COPY --from=build /app/packages/server/dist packages/server/dist/
-COPY --from=build /app/packages/server/COMMIT_SHA packages/server/COMMIT_SHA
 
 # Copy built client from build stage
 COPY --from=build /app/packages/client/build packages/client/build/
@@ -53,6 +48,8 @@ COPY --from=build /app/packages/client/build packages/client/build/
 # Copy database migration
 COPY packages/server/src/database/migrations/ packages/server/src/database/migrations/
 
+ARG COMMIT_SHA=unknown
+ENV COMMIT_SHA=$COMMIT_SHA
 ENV NODE_ENV=production
 ENV PORT=5000
 

--- a/packages/server/src/routes/status.ts
+++ b/packages/server/src/routes/status.ts
@@ -1,21 +1,12 @@
 import { Router, type IRouter } from 'express';
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
 
 const router: IRouter = Router();
-
-let commitSha = 'unknown';
-try {
-  commitSha = readFileSync(resolve(__dirname, '../../COMMIT_SHA'), 'utf-8').trim();
-} catch {
-  // Not available outside Docker builds — default to 'unknown'
-}
 
 const startedAt = new Date().toISOString();
 
 router.get('/', (_req, res) => {
   res.json({
-    version: commitSha,
+    version: process.env.COMMIT_SHA || 'unknown',
     uptime: process.uptime(),
     startedAt,
   });


### PR DESCRIPTION
## Summary
- Replace file-based COMMIT_SHA reading with `process.env.COMMIT_SHA`
- Move `ARG`/`ENV` to the production stage of the Dockerfile
- Remove the intermediate COMMIT_SHA file from the build

The file-based approach returned "unknown" because `__dirname` path resolution in the compiled JS didn't match the Docker image layout.

## Test plan
- [ ] Deploy and verify `/api/status` returns the correct commit SHA
- [ ] Run `./scripts/check-deploy.sh` to confirm deploy-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)