### PR TITLE
fix: detect cast disconnection when TV is powered off

### DIFF
--- a/packages/client/src/cast/cast-sender.d.ts
+++ b/packages/client/src/cast/cast-sender.d.ts
@@ -25,6 +25,10 @@ declare namespace cast.framework {
     castState: string;
   }
 
+  interface SessionStateEventData {
+    sessionState: string;
+  }
+
   const CastContextEventType: {
     CAST_STATE_CHANGED: string;
     SESSION_STATE_CHANGED: string;
@@ -35,6 +39,14 @@ declare namespace cast.framework {
     NOT_CONNECTED: string;
     CONNECTING: string;
     CONNECTED: string;
+  };
+
+  const SessionState: {
+    SESSION_STARTED: string;
+    SESSION_START_FAILED: string;
+    SESSION_RESUMED: string;
+    SESSION_ENDING: string;
+    SESSION_ENDED: string;
   };
 }
 

--- a/packages/client/src/cast/sender/useCastSession.ts
+++ b/packages/client/src/cast/sender/useCastSession.ts
@@ -43,6 +43,20 @@ export default function useCastSession(): CastSessionState {
         },
       );
 
+      // SESSION_STATE_CHANGED is more reliable for detecting abrupt disconnections
+      // (e.g. TV powered off) than CAST_STATE_CHANGED alone.
+      context.addEventListener(
+        cast.framework.CastContextEventType.SESSION_STATE_CHANGED,
+        (event: cast.framework.SessionStateEventData) => {
+          if (
+            event.sessionState === cast.framework.SessionState.SESSION_ENDED ||
+            event.sessionState === cast.framework.SessionState.SESSION_START_FAILED
+          ) {
+            setConnected(false);
+          }
+        },
+      );
+
       // Check initial state (event may have fired before listener was added)
       const initialState = context.getCastState();
       setAvailable(initialState !== cast.framework.CastState.NO_DEVICES_AVAILABLE);
@@ -74,7 +88,8 @@ export default function useCastSession(): CastSessionState {
     const session = cast.framework.CastContext.getInstance().getCurrentSession();
     if (session) {
       session.sendMessage(CAST_NAMESPACE, JSON.stringify(message)).catch(() => {
-        // Silently ignore — custom namespace fails on the default media receiver
+        // Message failure likely means receiver is gone
+        setConnected(false);
       });
     }
   }, []);


### PR DESCRIPTION
## Summary
- Add `SESSION_STATE_CHANGED` listener for reliable detection of abrupt disconnections (TV power-off)
- Mark as disconnected on `sendMessage` failure (receiver gone)
- Add `SessionState` type declarations for the Cast Sender SDK

## Test plan
- [ ] Start casting, then power off the TV — web app should show as disconnected
- [ ] Start casting, then stop via the cast button — still works as before
- [ ] Verify casting still connects and sends messages normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)