### PR TITLE
fix: auto-reconnect SSE when tab returns from background

### DIFF
--- a/packages/client/src/hooks/usePlaybackSSE.ts
+++ b/packages/client/src/hooks/usePlaybackSSE.ts
@@ -121,7 +121,20 @@ export default function usePlaybackSSE(): UsePlaybackSSEResult {
   useEffect(() => {
     connect();
 
+    // Reconnect when the tab becomes visible again (e.g. after being backgrounded).
+    // Browsers kill long-lived connections in background tabs, so the SSE connection
+    // will be dead when the user returns.
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        firstErrorAtRef.current = null;
+        setGaveUp(false);
+        connect();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
     return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
       if (eventSourceRef.current) {
         eventSourceRef.current.close();
       }


### PR DESCRIPTION
## Summary
- Listen for `visibilitychange` events in the SSE hook
- When the tab becomes visible, reset the give-up state and reconnect
- A successful SSE reconnect automatically clears the error overlay via the existing reducer logic

Previously, backgrounding the tab for >30s would permanently kill the SSE connection (gave up retrying), and since polling only runs when SSE hasn't given up, the app would get stuck showing "Connection lost" with no auto-recovery.

## Test plan
- [ ] Background the tab for >30 seconds, return — app should recover automatically
- [ ] If the session is truly expired (server restarted, etc.), the "Reconnect" button should still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)