### PR TITLE
feat: replace GitHub icon with help dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spune
 
-> Web-based Spotify "Now Playing" visualizer, inspired by the Zune desktop software.
+> A Spotify screensaver inspired by the Zune desktop software. Cast it to your TV with Chromecast.
 
 ![Zune Player 1](./assets/player.png)
 ![Zune Player 2](./assets/player2.png)
@@ -8,6 +8,8 @@
 ## Overview
 
 Spune displays album artwork from related artists in a Zune-style mosaic while you listen to Spotify. It discovers related artists via Last.fm and ListenBrainz, renders their album covers as an animated background, and can cast the visualization to a TV via Chromecast.
+
+It's meant to be used as a screensaver-style display — open it in a browser tab, or cast it to your TV for the full living room experience.
 
 ### Stack
 

--- a/packages/client/src/components/HelpDialog.css
+++ b/packages/client/src/components/HelpDialog.css
@@ -1,0 +1,78 @@
+.help-dialog {
+  position: absolute;
+  left: var(--spacing-overlay-inset);
+  top: calc(var(--spacing-overlay-inset) + 5px);
+  z-index: var(--z-overlay-chrome);
+}
+
+.help-dialog__trigger {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.help-dialog__panel {
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 0;
+  width: 280px;
+  padding: 16px;
+  background-color: var(--color-bg-surface);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-elevation-3);
+  z-index: var(--z-dropdown);
+}
+
+.help-dialog__title {
+  margin: 0 0 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.help-dialog__text {
+  margin: 0 0 8px;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  color: var(--color-text-secondary);
+}
+
+.help-dialog__text a {
+  color: var(--color-text-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.help-dialog__text a:hover {
+  color: var(--color-text-secondary);
+}
+
+.help-dialog__links {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  font-size: 0.8rem;
+}
+
+.help-dialog__links a {
+  color: var(--color-text-primary);
+  text-decoration: none;
+}
+
+.help-dialog__links a:hover {
+  color: var(--color-text-secondary);
+}
+
+.help-dialog__separator {
+  margin: 0 8px;
+  color: var(--color-text-secondary);
+}
+
+/* Breakpoint: 600px */
+@media (max-width: 600px) {
+  .help-dialog {
+    left: var(--spacing-overlay-inset-mobile);
+    top: calc(var(--spacing-overlay-inset-mobile) + 5px);
+  }
+}

--- a/packages/client/src/components/HelpDialog.css
+++ b/packages/client/src/components/HelpDialog.css
@@ -5,23 +5,11 @@
   z-index: var(--z-overlay-chrome);
 }
 
-.help-dialog__trigger {
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-}
-
 .help-dialog__panel {
-  position: absolute;
   top: calc(100% + 12px);
   left: 0;
   width: 280px;
   padding: 16px;
-  background-color: var(--color-bg-surface);
-  border-radius: var(--radius-sm);
-  box-shadow: var(--shadow-elevation-3);
-  z-index: var(--z-dropdown);
 }
 
 .help-dialog__title {
@@ -33,7 +21,7 @@
 
 .help-dialog__text {
   margin: 0 0 8px;
-  font-size: 0.8rem;
+  font-size: var(--font-size-sm);
   line-height: 1.4;
   color: var(--color-text-secondary);
 }
@@ -51,17 +39,8 @@
 .help-dialog__links {
   margin-top: 12px;
   padding-top: 10px;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
-  font-size: 0.8rem;
-}
-
-.help-dialog__links a {
-  color: var(--color-text-primary);
-  text-decoration: none;
-}
-
-.help-dialog__links a:hover {
-  color: var(--color-text-secondary);
+  border-top: 1px solid var(--color-border-subtle);
+  font-size: var(--font-size-sm);
 }
 
 .help-dialog__separator {

--- a/packages/client/src/components/HelpDialog.tsx
+++ b/packages/client/src/components/HelpDialog.tsx
@@ -1,0 +1,68 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCircleQuestion } from '@fortawesome/free-solid-svg-icons';
+import './HelpDialog.css';
+
+const REPO_URL = 'https://github.com/cdtinney/spune';
+const WEBSITE_URL = 'https://tinney.dev';
+
+export default function HelpDialog() {
+  const [open, setOpen] = useState(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dialogRef.current && e.target instanceof Node && !dialogRef.current.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') setOpen(false);
+  }, []);
+
+  return (
+    <div className="help-dialog" ref={dialogRef} onKeyDown={handleKeyDown}>
+      <button
+        className="help-dialog__trigger icon-interactive focus-ring"
+        onClick={() => setOpen(!open)}
+        aria-label="About Spune"
+        aria-expanded={open}
+      >
+        <FontAwesomeIcon icon={faCircleQuestion} size="lg" />
+      </button>
+
+      {open && (
+        <div className="help-dialog__panel" role="dialog" aria-label="About Spune">
+          <h2 className="help-dialog__title">Spune</h2>
+          <p className="help-dialog__text">
+            A Spotify visualizer inspired by the{' '}
+            <a href="https://en.wikipedia.org/wiki/Zune_Software" target="_blank" rel="noreferrer">
+              Zune desktop software
+            </a>
+            . It displays album artwork from related artists as an animated mosaic while you listen.
+          </p>
+          <p className="help-dialog__text">
+            Designed as a screensaver-style display — cast it to your TV with Chromecast for the
+            full experience.
+          </p>
+          <div className="help-dialog__links">
+            <a href={REPO_URL} target="_blank" rel="noreferrer">
+              GitHub
+            </a>
+            <span className="help-dialog__separator" aria-hidden="true">
+              &middot;
+            </span>
+            <span>Author: </span>
+            <a href={WEBSITE_URL} target="_blank" rel="noreferrer">
+              tinney.dev
+            </a>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/components/HelpDialog.tsx
+++ b/packages/client/src/components/HelpDialog.tsx
@@ -1,34 +1,19 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleQuestion } from '@fortawesome/free-solid-svg-icons';
+import useDropdown from '../hooks/useDropdown';
 import './HelpDialog.css';
 
 const REPO_URL = 'https://github.com/cdtinney/spune';
 const WEBSITE_URL = 'https://tinney.dev';
 
 export default function HelpDialog() {
-  const [open, setOpen] = useState(false);
-  const dialogRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (dialogRef.current && e.target instanceof Node && !dialogRef.current.contains(e.target)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
-
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') setOpen(false);
-  }, []);
+  const { open, ref, toggle, handleKeyDown } = useDropdown();
 
   return (
-    <div className="help-dialog" ref={dialogRef} onKeyDown={handleKeyDown}>
+    <div className="help-dialog" ref={ref} onKeyDown={handleKeyDown}>
       <button
         className="btn-unstyled icon-interactive focus-ring"
-        onClick={() => setOpen(!open)}
+        onClick={toggle}
         aria-label="About Spune"
         aria-expanded={open}
       >

--- a/packages/client/src/components/HelpDialog.tsx
+++ b/packages/client/src/components/HelpDialog.tsx
@@ -27,7 +27,7 @@ export default function HelpDialog() {
   return (
     <div className="help-dialog" ref={dialogRef} onKeyDown={handleKeyDown}>
       <button
-        className="help-dialog__trigger icon-interactive focus-ring"
+        className="btn-unstyled icon-interactive focus-ring"
         onClick={() => setOpen(!open)}
         aria-label="About Spune"
         aria-expanded={open}
@@ -36,7 +36,7 @@ export default function HelpDialog() {
       </button>
 
       {open && (
-        <div className="help-dialog__panel" role="dialog" aria-label="About Spune">
+        <div className="help-dialog__panel dropdown-panel" role="dialog" aria-label="About Spune">
           <h2 className="help-dialog__title">Spune</h2>
           <p className="help-dialog__text">
             A Spotify visualizer inspired by the{' '}
@@ -50,14 +50,14 @@ export default function HelpDialog() {
             full experience.
           </p>
           <div className="help-dialog__links">
-            <a href={REPO_URL} target="_blank" rel="noreferrer">
+            <a className="link-subtle" href={REPO_URL} target="_blank" rel="noreferrer">
               GitHub
             </a>
             <span className="help-dialog__separator" aria-hidden="true">
               &middot;
             </span>
             <span>Author: </span>
-            <a href={WEBSITE_URL} target="_blank" rel="noreferrer">
+            <a className="link-subtle" href={WEBSITE_URL} target="_blank" rel="noreferrer">
               tinney.dev
             </a>
           </div>

--- a/packages/client/src/components/UserMenu.css
+++ b/packages/client/src/components/UserMenu.css
@@ -5,22 +5,14 @@
 }
 
 .user-menu__trigger {
-  background: none;
-  border: none;
   margin-left: 8px;
   padding: 8px;
-  cursor: pointer;
 }
 
 .user-menu__dropdown {
-  position: absolute;
   top: 100%;
   right: 0;
   margin-top: 10px;
-  background-color: var(--color-bg-surface);
-  border-radius: var(--radius-sm);
-  box-shadow: var(--shadow-elevation-3);
-  z-index: var(--z-dropdown);
   min-width: 80px;
 }
 
@@ -31,7 +23,7 @@
   border: none;
   background: none;
   color: var(--color-text-primary);
-  font-size: 0.8rem;
+  font-size: var(--font-size-sm);
   text-align: left;
   cursor: pointer;
 }

--- a/packages/client/src/components/UserMenu.tsx
+++ b/packages/client/src/components/UserMenu.tsx
@@ -32,7 +32,7 @@ export default function UserMenu({ onLogout }: UserMenuProps) {
   return (
     <div className="user-menu" ref={menuRef}>
       <button
-        className="user-menu__trigger icon-interactive focus-ring"
+        className="user-menu__trigger btn-unstyled icon-interactive focus-ring"
         onClick={() => setOpen(!open)}
         onKeyDown={handleKeyDown}
         aria-label="User menu"
@@ -42,7 +42,7 @@ export default function UserMenu({ onLogout }: UserMenuProps) {
         <FontAwesomeIcon icon={faCaretDown} className="user-menu__icon" />
       </button>
       {open && (
-        <div className="user-menu__dropdown" role="menu">
+        <div className="user-menu__dropdown dropdown-panel" role="menu">
           <button className="user-menu__item" role="menuitem" onClick={onLogout}>
             Log Out
           </button>

--- a/packages/client/src/components/UserMenu.tsx
+++ b/packages/client/src/components/UserMenu.tsx
@@ -1,6 +1,6 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCaretDown } from '@fortawesome/free-solid-svg-icons';
+import useDropdown from '../hooks/useDropdown';
 import './UserMenu.css';
 
 interface UserMenuProps {
@@ -8,33 +8,13 @@ interface UserMenuProps {
 }
 
 export default function UserMenu({ onLogout }: UserMenuProps) {
-  const [open, setOpen] = useState<boolean>(false);
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent): void => {
-      if (menuRef.current && e.target instanceof Node && !menuRef.current.contains(e.target)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
-
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') setOpen(false);
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      setOpen((o) => !o);
-    }
-  }, []);
+  const { open, ref, toggle, handleKeyDown } = useDropdown();
 
   return (
-    <div className="user-menu" ref={menuRef}>
+    <div className="user-menu" ref={ref} onKeyDown={handleKeyDown}>
       <button
         className="user-menu__trigger btn-unstyled icon-interactive focus-ring"
-        onClick={() => setOpen(!open)}
-        onKeyDown={handleKeyDown}
+        onClick={toggle}
         aria-label="User menu"
         aria-expanded={open}
         aria-haspopup="true"

--- a/packages/client/src/hooks/useDropdown.ts
+++ b/packages/client/src/hooks/useDropdown.ts
@@ -1,0 +1,24 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+
+export default function useDropdown() {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && e.target instanceof Node && !ref.current.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const toggle = useCallback(() => setOpen((o) => !o), []);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') setOpen(false);
+  }, []);
+
+  return { open, ref, toggle, handleKeyDown };
+}

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -16,8 +16,12 @@
   --spacing-overlay-inset: 30px;
   --spacing-overlay-inset-mobile: 15px;
 
-  /* Border radius */
+  /* Typography */
+  --font-size-sm: 0.8rem;
+
+  /* Border */
   --radius-sm: 4px;
+  --color-border-subtle: rgba(255, 255, 255, 0.1);
 
   /* Z-index layers */
   --z-overlay-bg: 0;
@@ -84,6 +88,30 @@ body {
   outline: 2px solid var(--color-spotify-green);
   outline-offset: 2px;
   border-radius: var(--radius-sm);
+}
+
+.btn-unstyled {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.dropdown-panel {
+  position: absolute;
+  background-color: var(--color-bg-surface);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-elevation-3);
+  z-index: var(--z-dropdown);
+}
+
+.link-subtle {
+  color: var(--color-text-primary);
+  text-decoration: none;
+}
+
+.link-subtle:hover {
+  color: var(--color-text-secondary);
 }
 
 @keyframes fadein {

--- a/packages/client/src/pages/VisualizationContent.css
+++ b/packages/client/src/pages/VisualizationContent.css
@@ -15,13 +15,6 @@
   background-color: transparent;
 }
 
-.visualization__github-icon {
-  position: absolute;
-  left: var(--spacing-overlay-inset);
-  top: calc(var(--spacing-overlay-inset) + 5px);
-  z-index: var(--z-overlay-chrome);
-}
-
 .visualization__user-container {
   position: absolute;
   top: var(--spacing-overlay-inset);
@@ -83,10 +76,6 @@
 
 /* Breakpoint: 600px */
 @media (max-width: 600px) {
-  .visualization__github-icon {
-    display: none;
-  }
-
   .visualization__user-container {
     top: var(--spacing-overlay-inset-mobile);
     right: var(--spacing-overlay-inset-mobile);

--- a/packages/client/src/pages/VisualizationContent.tsx
+++ b/packages/client/src/pages/VisualizationContent.tsx
@@ -1,6 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faGithub } from '@fortawesome/free-brands-svg-icons';
+import HelpDialog from '../components/HelpDialog';
 import { useUser } from '../contexts/UserContext';
 import { useSpotify } from '../contexts/SpotifyContext';
 import useNowPlayingPoller from '../hooks/useNowPlayingPoller';
@@ -19,8 +18,6 @@ import CastButton from '../cast/sender/CastButton';
 import useCastSession from '../cast/sender/useCastSession';
 import type { CastMessage } from '../cast/types';
 import './VisualizationContent.css';
-
-const REPO_URL = 'https://github.com/cdtinney/spune';
 
 export default function VisualizationContent() {
   useNowPlayingPoller();
@@ -92,11 +89,7 @@ export default function VisualizationContent() {
 
       {!isInitialLoad && (
         <>
-          {!fullscreen && (
-            <a href={REPO_URL} className="visualization__github-icon icon-interactive">
-              <FontAwesomeIcon icon={faGithub} size="1x" />
-            </a>
-          )}
+          {!fullscreen && <HelpDialog />}
 
           <CastButton
             available={castSession.available}


### PR DESCRIPTION
## Summary
- Replace the GitHub icon with a help (?) button that opens an info panel
- Panel explains Spune is inspired by Zune and designed as a screensaver/Chromecast display
- Links to GitHub repo and tinney.dev
- Update README tagline to emphasize screensaver usage

## Test plan
- [ ] Click help icon — panel opens with correct text and links
- [ ] Click outside panel — closes
- [ ] Press Escape — closes
- [ ] Links open in new tabs
- [ ] Hidden in fullscreen mode
- [ ] Positioned correctly on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)