### PR TITLE
feat: add pg_cron keepalive to prevent Supabase pause

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -164,7 +164,9 @@
       "Bash(sed -i '' \"s|from ''../../hooks/useAlbumGrid''|from ''../../features/visualization/useAlbumGrid''|g\" cast/receiver/ReceiverApp.tsx)",
       "Bash(git reset:*)",
       "Bash(curl -sf http://127.0.0.1:3000)",
-      "Bash(git branch:*)"
+      "Bash(git branch:*)",
+      "Bash(find /Users/ctinney/Development/_Personal/spune -type f \\\\\\(-name *supabase* -o -name *migration* \\\\\\))",
+      "Bash(find /Users/ctinney/Development/_Personal/spune -type f -path */scripts/*)"
     ]
   }
 }

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,6 @@
 
 ## Testing
 
-<!-- How was this tested/how should it be tested? Use a list, but not checkboxes. Omit unnecessary prefixes like "Verified..." -->
+<!-- How was this tested/how should it be tested? Use a list of bullet points, but not checkboxes/checklists. Omit unnecessary prefixes like "Verified..." -->
 
 <!-- AI agent attribution is unnecessary for a personal project like this. -->

--- a/packages/server/SUPABASE.md
+++ b/packages/server/SUPABASE.md
@@ -56,6 +56,18 @@ CREATE POLICY "Server full access" ON users
   WITH CHECK (true);
 ```
 
+## 6. Keep-alive (free tier)
+
+Supabase pauses free-tier projects after 7 days of inactivity. To prevent this, run the second migration:
+
+```
+packages/server/src/database/migrations/002_keepalive.sql
+```
+
+This enables the `pg_cron` extension and schedules a daily row insert into a `_keepalive` table, which counts as database activity. Old rows are automatically cleaned up after 7 days.
+
+**Note:** `pg_cron` jobs run in the `postgres` database. If your connection string targets a different database, run this migration against `postgres` directly.
+
 ## Notes
 
 - The `postgres` role has superuser privileges and bypasses RLS by default. RLS policies only matter if you later add restricted roles (e.g., `anon` or `authenticated` via Supabase client).

--- a/packages/server/src/database/migrations/002_keepalive.sql
+++ b/packages/server/src/database/migrations/002_keepalive.sql
@@ -1,0 +1,24 @@
+-- Prevent Supabase free-tier project from pausing due to inactivity.
+-- pg_cron inserts a row once per day, keeping the project active.
+
+CREATE TABLE IF NOT EXISTS _keepalive (
+  id SERIAL PRIMARY KEY,
+  pinged_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- pg_cron is pre-installed on Supabase but must be explicitly enabled.
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- Insert a keepalive row every day at 00:00 UTC.
+SELECT cron.schedule(
+  'keepalive-ping',
+  '0 0 * * *',
+  $$INSERT INTO _keepalive (pinged_at) VALUES (now())$$
+);
+
+-- Purge rows older than 7 days every day at 00:05 UTC.
+SELECT cron.schedule(
+  'keepalive-cleanup',
+  '5 0 * * *',
+  $$DELETE FROM _keepalive WHERE pinged_at < now() - interval '7 days'$$
+);


### PR DESCRIPTION
## Summary

Adds a `pg_cron` keepalive migration to prevent the Supabase free-tier project from pausing due to inactivity (7-day threshold). A daily cron job inserts a row into a `_keepalive` table, and a second job purges rows older than 7 days.

## Testing

- Ran migration in Supabase SQL Editor
- Verify `pg_cron` extension is enabled: `SELECT * FROM pg_extension WHERE extname = 'pg_cron'`
- Verify jobs are scheduled: `SELECT * FROM cron.job`
- Manually insert to confirm table works: `INSERT INTO _keepalive (pinged_at) VALUES (now())`
- Wait 24h and confirm a row was auto-inserted