### PR TITLE
feat: add /api/health, request IDs, and HTTP access logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,13 +44,20 @@ packages/
 
 The client is a Vite SPA served at `127.0.0.1:3000` in dev. All `/api/*` requests are proxied to the Express server at `127.0.0.1:5000` via Vite's dev proxy. In production, the Express server serves the built client as static files.
 
-Three API endpoints:
+API endpoints:
 
 - `GET /api/auth/user` — returns the authenticated user (or empty object)
 - `GET /api/spotify/me/player` — returns the current playback state
 - `GET /api/spotify/currently-playing/related-albums?songId=<id>` — returns related artist albums
+- `GET /api/status` — returns `{ version, uptime, startedAt }`. Used by the deploy-check job to verify the droplet is running the new image.
+- `GET /api/health` — returns `200 { status: 'ok', db: 'ok' }` when the server can reach PostgreSQL via `SELECT 1`, or `503 { status: 'error', db: 'down' }` otherwise. Not rate-limited; safe for uptime monitors to poll.
 
 The client polls `/api/spotify/me/player` every 3 seconds. When the album changes, it fetches related albums.
+
+### Observability
+
+- **Request IDs**: every request gets an `X-Request-Id`. Trusted inbound IDs (alphanumeric, `_`, `.`, `:`, `-`, ≤128 chars) are preserved; otherwise a UUID is generated. The same value is echoed back as a response header and is attached to every Winston log entry emitted on that request via `AsyncLocalStorage`. To pull the current ID inside a handler, import `getRequestId` from `middleware/requestContext`.
+- **Access logs**: `httpLogger` middleware emits one `http_request` log line per response with `{ method, url, status, durationMs }`. `/api/health` is skipped to avoid noise from frequent uptime polls.
 
 ### Auth Flow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,14 +50,14 @@ API endpoints:
 - `GET /api/spotify/me/player` — returns the current playback state
 - `GET /api/spotify/currently-playing/related-albums?songId=<id>` — returns related artist albums
 - `GET /api/status` — returns `{ version, uptime, startedAt }`. Used by the deploy-check job to verify the droplet is running the new image.
-- `GET /api/health` — returns `200 { status: 'ok', db: 'ok' }` when the server can reach PostgreSQL via `SELECT 1`, or `503 { status: 'error', db: 'down' }` otherwise. Not rate-limited; safe for uptime monitors to poll.
+- `GET /api/health` — returns `200 { status: 'ok' }` when the server can reach PostgreSQL via `SELECT 1`, or `503 { status: 'error' }` otherwise. Not rate-limited; safe for uptime monitors to poll.
 
 The client polls `/api/spotify/me/player` every 3 seconds. When the album changes, it fetches related albums.
 
 ### Observability
 
 - **Request IDs**: every request gets an `X-Request-Id`. Trusted inbound IDs (alphanumeric, `_`, `.`, `:`, `-`, ≤128 chars) are preserved; otherwise a UUID is generated. The same value is echoed back as a response header and is attached to every Winston log entry emitted on that request via `AsyncLocalStorage`. To pull the current ID inside a handler, import `getRequestId` from `middleware/requestContext`.
-- **Access logs**: `httpLogger` middleware emits one `http_request` log line per response with `{ method, url, status, durationMs }`. `/api/health` is skipped to avoid noise from frequent uptime polls.
+- **Access logs**: `httpLogger` middleware emits one `http_request` log line per response with `{ method, url, status, durationMs }`. `/api/health` and SSE streams (`/api/sse/*`) are skipped — the former is noise, the latter would record stream lifetime instead of request work.
 
 ### Auth Flow
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -98,6 +98,16 @@ You can also run the check manually:
 
 Rate-limited to 30 requests per 15 minutes.
 
+### Health endpoint
+
+`GET /api/health` returns `200 { "status": "ok", "db": "ok" }` when the server can reach PostgreSQL via `SELECT 1` within ~2s, or `503 { "status": "error", "db": "down" }` otherwise. Not rate-limited; safe for an external uptime monitor to poll.
+
+### Request IDs and access logs
+
+Every request gets an `X-Request-Id` header (preserved from inbound when valid, otherwise generated). The same value is echoed back to the client and included in every server log entry on that request, so a single ID can correlate a client report with the matching log lines.
+
+The server emits one `http_request` log line per response with `{ method, url, status, durationMs, requestId }`. `/api/health` is excluded to avoid log noise from frequent monitor polls.
+
 ## Debugging
 
 ```bash

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -100,13 +100,13 @@ Rate-limited to 30 requests per 15 minutes.
 
 ### Health endpoint
 
-`GET /api/health` returns `200 { "status": "ok", "db": "ok" }` when the server can reach PostgreSQL via `SELECT 1` within ~2s, or `503 { "status": "error", "db": "down" }` otherwise. Not rate-limited; safe for an external uptime monitor to poll.
+`GET /api/health` returns `200 { "status": "ok" }` when the server can reach PostgreSQL via `SELECT 1` within ~2s, or `503 { "status": "error" }` otherwise. Not rate-limited; safe for an external uptime monitor to poll. When the check fails, the underlying error is logged at `warn` level under `[health] DB check failed`.
 
 ### Request IDs and access logs
 
 Every request gets an `X-Request-Id` header (preserved from inbound when valid, otherwise generated). The same value is echoed back to the client and included in every server log entry on that request, so a single ID can correlate a client report with the matching log lines.
 
-The server emits one `http_request` log line per response with `{ method, url, status, durationMs, requestId }`. `/api/health` is excluded to avoid log noise from frequent monitor polls.
+The server emits one `http_request` log line per response with `{ method, url, status, durationMs, requestId }`. `/api/health` (noise) and SSE streams (would record stream lifetime, not request work) are skipped.
 
 ## Debugging
 

--- a/docs/tasks/16-production-readiness.md
+++ b/docs/tasks/16-production-readiness.md
@@ -29,10 +29,10 @@ Spune currently runs as a side project with minimal production hardening. Before
 
 ### Observability & monitoring
 
-- **Health check endpoint**: Add a `/health` endpoint that verifies the server is running and can reach the database.
-- **Structured logging**: Replace any `console.log` with a structured logger (e.g. pino) that outputs JSON in production. Include request IDs for tracing.
+- ~~**Health check endpoint**: Add a `/health` endpoint that verifies the server is running and can reach the database.~~ Done — `GET /api/health` runs `SELECT 1` with a ~2s timeout and returns 200/503.
+- ~~**Structured logging**: Replace any `console.log` with a structured logger that outputs JSON in production. Include request IDs for tracing.~~ Done — Winston already produces JSON; per-request IDs (via `AsyncLocalStorage`) are now attached to every log line, and an `http_request` access log is emitted per response.
 - **Error tracking**: Integrate an error tracking service (e.g. Sentry) for both client and server to capture unhandled exceptions.
-- **Uptime monitoring**: Set up external uptime monitoring that alerts on downtime or degraded performance.
+- **Uptime monitoring**: Set up external uptime monitoring (pointed at `/api/health`) that alerts on downtime or degraded performance.
 
 ### Operational hygiene
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -29,10 +29,10 @@ src/
 
 ## Operational endpoints
 
-| Endpoint          | Purpose                                                                                                                                                                           |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `GET /api/status` | Returns `{ version, uptime, startedAt }`. Used by the deploy-check job to confirm the droplet is running the new image.                                                           |
-| `GET /api/health` | Returns `200 { status: 'ok', db: 'ok' }` when `SELECT 1` succeeds within ~2s, or `503 { status: 'error', db: 'down' }` otherwise. Not rate-limited; suitable for uptime monitors. |
+| Endpoint          | Purpose                                                                                                                                                     |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /api/status` | Returns `{ version, uptime, startedAt }`. Used by the deploy-check job to confirm the droplet is running the new image.                                     |
+| `GET /api/health` | Returns `200 { status: 'ok' }` when `SELECT 1` succeeds within ~2s, or `503 { status: 'error' }` otherwise. Not rate-limited; suitable for uptime monitors. |
 
 ## Configuration
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -10,8 +10,9 @@ src/
   cache/        # In-memory LRU caches for API responses
   config/       # App configuration (paths, env)
   database/     # PostgreSQL connection, queries, migrations
-  middleware/    # Rate limiting
-  routes/       # API routes (auth, spotify, SSE)
+  logger/       # Winston logger setup (auto-injects requestId from AsyncLocalStorage)
+  middleware/   # Rate limiting, request context (request IDs), HTTP access log
+  routes/       # API routes (auth, spotify, SSE, status, health)
   spotify/      # Spotify API integration (SDK wrapper, helpers)
   sse/          # Server-Sent Events broadcaster
   types/        # TypeScript type definitions
@@ -24,6 +25,14 @@ src/
 - **SSE push**: Server polls Spotify and pushes playback state to connected clients
 - **Token refresh**: Automatic Spotify token refresh via passport-oauth2-refresh
 - **Token encryption at rest**: Spotify access/refresh tokens are AES-256-GCM encrypted before being written to the `users` table; key comes from `TOKEN_ENCRYPTION_KEY`
+- **Request IDs + access logs**: every request gets an `X-Request-Id` (preserved from inbound when valid, otherwise generated) that is echoed back and attached to every log line via `AsyncLocalStorage`. One `http_request` log line is emitted per response.
+
+## Operational endpoints
+
+| Endpoint          | Purpose                                                                                                                                                                           |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /api/status` | Returns `{ version, uptime, startedAt }`. Used by the deploy-check job to confirm the droplet is running the new image.                                                           |
+| `GET /api/health` | Returns `200 { status: 'ok', db: 'ok' }` when `SELECT 1` succeeds within ~2s, or `503 { status: 'error', db: 'down' }` otherwise. Not rate-limited; suitable for uptime monitors. |
 
 ## Configuration
 

--- a/packages/server/src/createApp.ts
+++ b/packages/server/src/createApp.ts
@@ -34,8 +34,7 @@ export default function createApp(): express.Application {
   // Trust reverse proxy (Caddy) so Express sees correct protocol/IP
   app.set('trust proxy', 1);
 
-  // Per-request ID + access log. Must run before routes so every log entry on the
-  // request path picks up the ID from AsyncLocalStorage.
+  // Must run before routes so downstream log entries inherit the request ID via AsyncLocalStorage.
   app.use(requestContext);
   app.use(httpLogger);
 

--- a/packages/server/src/createApp.ts
+++ b/packages/server/src/createApp.ts
@@ -10,6 +10,8 @@ import routes from './routes/index';
 import paths from './config/paths';
 import configurePassport from './auth/configurePassport';
 import { verifyTokenEncryptionConfigured } from './auth/tokenCrypto';
+import requestContext from './middleware/requestContext';
+import httpLogger from './middleware/httpLogger';
 
 const PgSession = connectPgSimple(session);
 
@@ -31,6 +33,11 @@ export default function createApp(): express.Application {
 
   // Trust reverse proxy (Caddy) so Express sees correct protocol/IP
   app.set('trust proxy', 1);
+
+  // Per-request ID + access log. Must run before routes so every log entry on the
+  // request path picks up the ID from AsyncLocalStorage.
+  app.use(requestContext);
+  app.use(httpLogger);
 
   app.use(express.urlencoded({ extended: false }));
   app.use(express.json());

--- a/packages/server/src/logger/logger.ts
+++ b/packages/server/src/logger/logger.ts
@@ -1,4 +1,11 @@
 import { createLogger, format, transports } from 'winston';
+import { getRequestId } from '../middleware/requestContext';
+
+const requestIdFormat = format((info) => {
+  const requestId = getRequestId();
+  if (requestId) info.requestId = requestId;
+  return info;
+});
 
 const logger = createLogger({
   level: 'info',
@@ -10,6 +17,7 @@ const logger = createLogger({
       stack: true,
     }),
     format.splat(),
+    requestIdFormat(),
     format.json(),
   ),
   defaultMeta: {

--- a/packages/server/src/middleware/__tests__/httpLogger.test.ts
+++ b/packages/server/src/middleware/__tests__/httpLogger.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import logger from '../../logger';
+import httpLogger from '../httpLogger';
+
+function buildApp() {
+  const app = express();
+  app.use(httpLogger);
+  app.get('/api/spotify/me/player', (_req, res) => res.json({ ok: true }));
+  app.get('/api/health', (_req, res) => res.json({ ok: true }));
+  app.get('/boom', (_req, _res, next) => next(new Error('boom')));
+  return app;
+}
+
+describe('httpLogger middleware', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(logger, 'info').mockImplementation(() => logger);
+  });
+
+  it('logs one entry with method, url, status, durationMs', async () => {
+    await request(buildApp()).get('/api/spotify/me/player');
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    const [meta] = vi.mocked(logger.info).mock.calls[0] as [Record<string, unknown>];
+    expect(meta).toMatchObject({
+      message: 'http_request',
+      method: 'GET',
+      url: '/api/spotify/me/player',
+      status: 200,
+    });
+    expect(typeof meta.durationMs).toBe('number');
+  });
+
+  it('skips /api/health', async () => {
+    await request(buildApp()).get('/api/health');
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it('still logs error responses with the error status code', async () => {
+    await request(buildApp()).get('/boom');
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    const [meta] = vi.mocked(logger.info).mock.calls[0] as [Record<string, unknown>];
+    expect(meta.status).toBe(500);
+  });
+});

--- a/packages/server/src/middleware/__tests__/httpLogger.test.ts
+++ b/packages/server/src/middleware/__tests__/httpLogger.test.ts
@@ -9,6 +9,7 @@ function buildApp() {
   app.use(httpLogger);
   app.get('/api/spotify/me/player', (_req, res) => res.json({ ok: true }));
   app.get('/api/health', (_req, res) => res.json({ ok: true }));
+  app.get('/api/sse/playback', (_req, res) => res.json({ ok: true }));
   app.get('/boom', (_req, _res, next) => next(new Error('boom')));
   return app;
 }
@@ -35,6 +36,11 @@ describe('httpLogger middleware', () => {
 
   it('skips /api/health', async () => {
     await request(buildApp()).get('/api/health');
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it('skips SSE streams', async () => {
+    await request(buildApp()).get('/api/sse/playback');
     expect(logger.info).not.toHaveBeenCalled();
   });
 

--- a/packages/server/src/middleware/__tests__/requestContext.test.ts
+++ b/packages/server/src/middleware/__tests__/requestContext.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import requestContext, { getRequestId } from '../requestContext';
+
+function buildApp() {
+  const app = express();
+  app.use(requestContext);
+  app.get('/echo', (_req, res) => {
+    res.json({ requestId: getRequestId() });
+  });
+  return app;
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+describe('requestContext middleware', () => {
+  it('returns undefined from getRequestId() outside an active request', () => {
+    expect(getRequestId()).toBeUndefined();
+  });
+
+  it('generates a UUID when no X-Request-Id header is present', async () => {
+    const res = await request(buildApp()).get('/echo');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.requestId).toMatch(UUID_RE);
+    expect(res.headers['x-request-id']).toBe(res.body.requestId);
+  });
+
+  it('preserves a valid inbound X-Request-Id header', async () => {
+    const inbound = 'trace-abc_123.45:67';
+    const res = await request(buildApp()).get('/echo').set('X-Request-Id', inbound);
+    expect(res.body.requestId).toBe(inbound);
+    expect(res.headers['x-request-id']).toBe(inbound);
+  });
+
+  it('replaces an inbound header with disallowed characters', async () => {
+    const res = await request(buildApp()).get('/echo').set('X-Request-Id', 'has spaces');
+    expect(res.body.requestId).not.toBe('has spaces');
+    expect(res.body.requestId).toMatch(UUID_RE);
+  });
+
+  it('replaces an inbound header that is too long', async () => {
+    const tooLong = 'a'.repeat(200);
+    const res = await request(buildApp()).get('/echo').set('X-Request-Id', tooLong);
+    expect(res.body.requestId).not.toBe(tooLong);
+    expect(res.body.requestId).toMatch(UUID_RE);
+  });
+
+  it('isolates request IDs across concurrent requests', async () => {
+    const app = buildApp();
+    const [a, b] = await Promise.all([
+      request(app).get('/echo').set('X-Request-Id', 'req-a'),
+      request(app).get('/echo').set('X-Request-Id', 'req-b'),
+    ]);
+    expect(a.body.requestId).toBe('req-a');
+    expect(b.body.requestId).toBe('req-b');
+  });
+});

--- a/packages/server/src/middleware/httpLogger.ts
+++ b/packages/server/src/middleware/httpLogger.ts
@@ -1,0 +1,28 @@
+import type { RequestHandler } from 'express';
+import logger from '../logger';
+
+const SKIP_PATHS = new Set(['/api/health']);
+
+const httpLogger: RequestHandler = (req, res, next) => {
+  if (SKIP_PATHS.has(req.path)) {
+    next();
+    return;
+  }
+
+  const start = process.hrtime.bigint();
+
+  res.on('finish', () => {
+    const durationMs = Number(process.hrtime.bigint() - start) / 1e6;
+    logger.info({
+      message: 'http_request',
+      method: req.method,
+      url: req.originalUrl,
+      status: res.statusCode,
+      durationMs: Math.round(durationMs * 100) / 100,
+    });
+  });
+
+  next();
+};
+
+export default httpLogger;

--- a/packages/server/src/middleware/httpLogger.ts
+++ b/packages/server/src/middleware/httpLogger.ts
@@ -1,10 +1,13 @@
 import type { RequestHandler } from 'express';
 import logger from '../logger';
 
-const SKIP_PATHS = new Set(['/api/health']);
+// Skip uptime polls (noise) and SSE streams (durationMs would measure stream lifetime, not request work).
+function shouldSkip(path: string): boolean {
+  return path === '/api/health' || path.startsWith('/api/sse/');
+}
 
 const httpLogger: RequestHandler = (req, res, next) => {
-  if (SKIP_PATHS.has(req.path)) {
+  if (shouldSkip(req.path)) {
     next();
     return;
   }

--- a/packages/server/src/middleware/requestContext.ts
+++ b/packages/server/src/middleware/requestContext.ts
@@ -1,0 +1,39 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { randomUUID } from 'node:crypto';
+import type { RequestHandler } from 'express';
+
+type RequestContext = {
+  requestId: string;
+};
+
+const storage = new AsyncLocalStorage<RequestContext>();
+
+// Reject untrusted client headers — IDs longer than this are almost certainly garbage.
+const MAX_INBOUND_ID_LENGTH = 128;
+const SAFE_ID_PATTERN = /^[A-Za-z0-9_.:-]+$/;
+
+function resolveRequestId(headerValue: unknown): string {
+  if (typeof headerValue === 'string') {
+    const trimmed = headerValue.trim();
+    if (
+      trimmed.length > 0 &&
+      trimmed.length <= MAX_INBOUND_ID_LENGTH &&
+      SAFE_ID_PATTERN.test(trimmed)
+    ) {
+      return trimmed;
+    }
+  }
+  return randomUUID();
+}
+
+export function getRequestId(): string | undefined {
+  return storage.getStore()?.requestId;
+}
+
+const requestContext: RequestHandler = (req, res, next) => {
+  const requestId = resolveRequestId(req.headers['x-request-id']);
+  res.setHeader('X-Request-Id', requestId);
+  storage.run({ requestId }, () => next());
+};
+
+export default requestContext;

--- a/packages/server/src/middleware/requestContext.ts
+++ b/packages/server/src/middleware/requestContext.ts
@@ -12,9 +12,10 @@ const storage = new AsyncLocalStorage<RequestContext>();
 const MAX_INBOUND_ID_LENGTH = 128;
 const SAFE_ID_PATTERN = /^[A-Za-z0-9_.:-]+$/;
 
-function resolveRequestId(headerValue: unknown): string {
-  if (typeof headerValue === 'string') {
-    const trimmed = headerValue.trim();
+function resolveRequestId(headerValue: string | string[] | undefined): string {
+  const candidate = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+  if (candidate) {
+    const trimmed = candidate.trim();
     if (
       trimmed.length > 0 &&
       trimmed.length <= MAX_INBOUND_ID_LENGTH &&

--- a/packages/server/src/routes/__tests__/health.test.ts
+++ b/packages/server/src/routes/__tests__/health.test.ts
@@ -21,7 +21,7 @@ describe('/api/health', () => {
     const res = await request(buildApp()).get('/api/health');
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toEqual({ status: 'ok', db: 'ok' });
+    expect(res.body).toEqual({ status: 'ok' });
   });
 
   it('returns 503 when the DB query fails', async () => {
@@ -30,6 +30,6 @@ describe('/api/health', () => {
     const res = await request(buildApp()).get('/api/health');
 
     expect(res.statusCode).toBe(503);
-    expect(res.body).toEqual({ status: 'error', db: 'down' });
+    expect(res.body).toEqual({ status: 'error' });
   });
 });

--- a/packages/server/src/routes/__tests__/health.test.ts
+++ b/packages/server/src/routes/__tests__/health.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { pool } from '../../database/db';
+import healthRoutes from '../health';
+
+function buildApp() {
+  const app = express();
+  app.use('/api/health', healthRoutes);
+  return app;
+}
+
+describe('/api/health', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns 200 with status ok when the DB responds', async () => {
+    vi.spyOn(pool, 'query').mockResolvedValue({ rows: [] } as never);
+
+    const res = await request(buildApp()).get('/api/health');
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ status: 'ok', db: 'ok' });
+  });
+
+  it('returns 503 when the DB query fails', async () => {
+    vi.spyOn(pool, 'query').mockRejectedValue(new Error('connection refused'));
+
+    const res = await request(buildApp()).get('/api/health');
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toEqual({ status: 'error', db: 'down' });
+  });
+});

--- a/packages/server/src/routes/health.ts
+++ b/packages/server/src/routes/health.ts
@@ -1,0 +1,33 @@
+import { Router, type IRouter } from 'express';
+import { pool } from '../database/db';
+import logger from '../logger';
+
+const router: IRouter = Router();
+
+const DB_CHECK_TIMEOUT_MS = 2000;
+
+async function checkDatabase(): Promise<boolean> {
+  let timeoutId: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error('db check timed out')), DB_CHECK_TIMEOUT_MS);
+  });
+  try {
+    await Promise.race([pool.query('SELECT 1'), timeout]);
+    return true;
+  } catch (err) {
+    logger.warn('[health] DB check failed', { error: err instanceof Error ? err.message : err });
+    return false;
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
+router.get('/', async (_req, res) => {
+  const dbOk = await checkDatabase();
+  res.status(dbOk ? 200 : 503).json({
+    status: dbOk ? 'ok' : 'error',
+    db: dbOk ? 'ok' : 'down',
+  });
+});
+
+export default router;

--- a/packages/server/src/routes/health.ts
+++ b/packages/server/src/routes/health.ts
@@ -12,6 +12,8 @@ async function checkDatabase(): Promise<boolean> {
     timeoutId = setTimeout(() => reject(new Error('db check timed out')), DB_CHECK_TIMEOUT_MS);
   });
   try {
+    // Promise.race only bounds the HTTP response time. The underlying pg query is uncancellable,
+    // so a hung DB pins one pool client per stuck health check until pg's socket layer aborts.
     await Promise.race([pool.query('SELECT 1'), timeout]);
     return true;
   } catch (err) {

--- a/packages/server/src/routes/health.ts
+++ b/packages/server/src/routes/health.ts
@@ -24,10 +24,7 @@ async function checkDatabase(): Promise<boolean> {
 
 router.get('/', async (_req, res) => {
   const dbOk = await checkDatabase();
-  res.status(dbOk ? 200 : 503).json({
-    status: dbOk ? 'ok' : 'error',
-    db: dbOk ? 'ok' : 'down',
-  });
+  res.status(dbOk ? 200 : 503).json({ status: dbOk ? 'ok' : 'error' });
 });
 
 export default router;

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -8,10 +8,9 @@ import statusRoutes from './status';
 
 const router: IRouter = Router();
 
-// Mount uptime/health checks before any rate limiter so external monitors can poll freely.
+// Health check is mounted before the rate limiter so uptime monitors can poll freely.
 router.use('/health', healthRoutes);
 
-// Apply general rate limit to all remaining API routes.
 router.use(apiLimiter);
 
 // Apply stricter limits per route group.

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -1,13 +1,17 @@
 import { Router, type IRouter } from 'express';
 import { apiLimiter, authLimiter, spotifyLimiter, statusLimiter } from '../middleware/rateLimiter';
 import authRoutes from './auth';
+import healthRoutes from './health';
 import spotifyRoutes from './spotify';
 import sseRoutes from './sse';
 import statusRoutes from './status';
 
 const router: IRouter = Router();
 
-// Apply general rate limit to all API routes.
+// Mount uptime/health checks before any rate limiter so external monitors can poll freely.
+router.use('/health', healthRoutes);
+
+// Apply general rate limit to all remaining API routes.
 router.use(apiLimiter);
 
 // Apply stricter limits per route group.


### PR DESCRIPTION
## Summary

Adds three observability primitives toward Task 16 (production readiness) — small, free, industry-standard, and complementary:

- **`GET /api/health`** — runs `SELECT 1` against the pool with a ~2s timeout. Returns `200 { status: 'ok' }` when healthy, `503 { status: 'error' }` otherwise. Mounted before the rate limiter so external uptime monitors can poll freely.
- **Request IDs** — `requestContext` middleware preserves a valid inbound `X-Request-Id` (alphanumeric / `_.:-`, ≤128 chars) or generates a UUID, echoes it back as a response header, and runs the rest of the request inside an `AsyncLocalStorage` scope. The Winston format pulls the ID out of ALS so every log line on a request carries it automatically.
- **HTTP access log** — `httpLogger` middleware emits one `http_request` log entry per response with `method`, `url`, `status`, `durationMs`. `/api/health` (noise) and SSE streams (`/api/sse/*`, would record stream lifetime) are skipped.

Zero new runtime deps (uses Node built-ins `crypto.randomUUID` and `async_hooks`). Winston was already in place and is reused.

Docs updated: `AGENTS.md`, `packages/server/README.md`, `docs/deployment.md`, and the production-readiness task doc.

## Testing

- 12 new unit tests (`requestContext.test.ts`, `httpLogger.test.ts`, `health.test.ts`); existing 59 server tests still pass for a total of 71.
- Covers UUID generation, inbound-ID preservation, rejection of malformed inbound IDs, ALS isolation across concurrent requests, log entry shape, `/api/health` and SSE skip in the access log, and 200/503 responses for DB up/down.
- Build typecheck (`tsconfig.build.json`) and lint pass.
- The deploy-check uses `/api/status`, which is unchanged.