### PR TITLE
chore: add logout-all-users recovery script

### DIFF
--- a/scripts/logout-all-users.sh
+++ b/scripts/logout-all-users.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Log out every Spune user by clearing the session table on the droplet.
+#
+# Useful when stale session cookies point at user rows the server can't
+# deserialize — e.g. after a token-encryption rollout, when pre-existing
+# rows hold plaintext tokens the new decrypt path rejects and every
+# authenticated request 500s before the user can reach /auth/user/logout.
+# Once the session table is empty, the next request runs the OAuth flow,
+# which rewrites the user row with freshly-encrypted tokens via the
+# findOrCreateUser ON CONFLICT update.
+#
+# Usage (run on the droplet):
+#   bash logout-all-users.sh        # prompts for confirmation
+#   bash logout-all-users.sh --yes  # skip the prompt
+set -euo pipefail
+
+COMPOSE=(docker compose -f /opt/spune/docker-compose.yml)
+
+if [[ "${1:-}" != "--yes" ]]; then
+  read -r -p "This logs out every Spune user. Continue? [y/N] " reply
+  case "$reply" in
+    y|Y|yes|YES) ;;
+    *) echo "Aborted."; exit 1 ;;
+  esac
+fi
+
+echo "==> Clearing session table..."
+"${COMPOSE[@]}" exec -T db psql -U spune -d spune -v ON_ERROR_STOP=1 \
+  -c "DELETE FROM session;"
+
+echo "==> Done. Every user will be redirected to log in on their next request."


### PR DESCRIPTION
## Summary

Adds `scripts/logout-all-users.sh`, run on the droplet to clear the `session` table when stale cookies point at user rows the server can't deserialize.

Concretely: after the token-encryption rollout in #204, pre-existing user rows still hold plaintext access/refresh tokens. The new `decryptToken` path requires a `v1:` prefix and throws on anything else, so passport's `deserializeUser` (which calls `findUserBySpotifyId` → `toUser`) throws on every authenticated request — including `/api/auth/user/logout`. The user has no in-app way to recover.

Wiping the `session` table breaks the cookie → user mapping. The next request runs the OAuth flow, and `findOrCreateUser`'s `ON CONFLICT … DO UPDATE` rewrites both token columns with freshly-encrypted (`v1:`-prefixed) values, so the stale rows fix themselves on next login. No need to touch the `users` table.

Hardcoded to `/opt/spune/docker-compose.yml` to match `migrate.sh` / `logs.sh`. Uses `DELETE` over `TRUNCATE` (works under any privilege level, transactional). Confirmation prompt by default; `--yes` to skip.

## Testing

- `bash -n scripts/logout-all-users.sh` — syntax check passes.
- Manually traced the recovery flow: empty `session` table → next request has no `passport.user` on `req.session` → passport doesn't call `deserializeUser` → no decrypt error → `/api/auth/spotify` redirect works → callback runs `findOrCreateUser` → row rewritten with `v1:` tokens.