### PR TITLE
fix: treat undecryptable user rows as not-found

### DIFF
--- a/packages/server/src/database/queries/__tests__/userQueries.test.ts
+++ b/packages/server/src/database/queries/__tests__/userQueries.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../../auth/tokenCrypto', () => ({
 
 import { pool } from '../../db';
 import { decryptToken } from '../../../auth/tokenCrypto';
+import logger from '../../../logger';
 import { findUserBySpotifyId } from '../userQueries';
 
 const fakeRow = {
@@ -46,7 +47,7 @@ describe('findUserBySpotifyId()', () => {
     });
   });
 
-  it('returns null when a stored token cannot be decrypted', async () => {
+  it('returns null and warns when a stored token cannot be decrypted', async () => {
     // Legacy plaintext rows (from before encryption-at-rest) make decryptToken
     // throw. Without this branch, every authenticated request 500s in
     // passport's deserializeUser before the user can reach logout.
@@ -54,7 +55,11 @@ describe('findUserBySpotifyId()', () => {
     vi.mocked(decryptToken).mockImplementation(() => {
       throw new Error('Token is not in encrypted format (missing version prefix).');
     });
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined as never);
 
     expect(await findUserBySpotifyId('spot-1')).toBeNull();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('dropping unreadable user row'));
+
+    warn.mockRestore();
   });
 });

--- a/packages/server/src/database/queries/__tests__/userQueries.test.ts
+++ b/packages/server/src/database/queries/__tests__/userQueries.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../db', () => ({
+  pool: { query: vi.fn() },
+}));
+
+vi.mock('../../../auth/tokenCrypto', () => ({
+  decryptToken: vi.fn(),
+  encryptToken: vi.fn(),
+}));
+
+import { pool } from '../../db';
+import { decryptToken } from '../../../auth/tokenCrypto';
+import { findUserBySpotifyId } from '../userQueries';
+
+const fakeRow = {
+  id: 1,
+  spotify_id: 'spot-1',
+  spotify_access_token: 'enc-access',
+  spotify_refresh_token: 'enc-refresh',
+  token_updated: 123,
+  expires_in: 3600,
+  display_name: 'Alice',
+  photos: [],
+};
+
+describe('findUserBySpotifyId()', () => {
+  beforeEach(() => {
+    vi.mocked(pool.query).mockReset();
+    vi.mocked(decryptToken).mockReset();
+  });
+
+  it('returns null when no row matches', async () => {
+    vi.mocked(pool.query).mockResolvedValue({ rows: [] } as never);
+    expect(await findUserBySpotifyId('missing')).toBeNull();
+  });
+
+  it('returns the user when tokens decrypt successfully', async () => {
+    vi.mocked(pool.query).mockResolvedValue({ rows: [fakeRow] } as never);
+    vi.mocked(decryptToken).mockImplementation((v: string) => `decrypted:${v}`);
+
+    expect(await findUserBySpotifyId('spot-1')).toMatchObject({
+      spotifyId: 'spot-1',
+      spotifyAccessToken: 'decrypted:enc-access',
+      spotifyRefreshToken: 'decrypted:enc-refresh',
+    });
+  });
+
+  it('returns null when a stored token cannot be decrypted', async () => {
+    // Legacy plaintext rows (from before encryption-at-rest) make decryptToken
+    // throw. Without this branch, every authenticated request 500s in
+    // passport's deserializeUser before the user can reach logout.
+    vi.mocked(pool.query).mockResolvedValue({ rows: [fakeRow] } as never);
+    vi.mocked(decryptToken).mockImplementation(() => {
+      throw new Error('Token is not in encrypted format (missing version prefix).');
+    });
+
+    expect(await findUserBySpotifyId('spot-1')).toBeNull();
+  });
+});

--- a/packages/server/src/database/queries/userQueries.ts
+++ b/packages/server/src/database/queries/userQueries.ts
@@ -1,5 +1,7 @@
 import { pool } from '../db';
 import { encryptToken, decryptToken } from '../../auth/tokenCrypto';
+import errorMessage from '../../utils/errorMessage';
+import logger from '../../logger';
 import type { User, UserRow, SpotifyPhoto } from '../../types';
 
 interface FindOrCreateUserData {
@@ -45,7 +47,18 @@ async function findUserBySpotifyId(spotifyId: string): Promise<User | null> {
   const result = await pool.query<UserRow>('SELECT * FROM users WHERE spotify_id = $1 LIMIT 1', [
     spotifyId,
   ]);
-  return result.rows[0] ? toUser(result.rows[0]) : null;
+  const row = result.rows[0];
+  if (!row) return null;
+  // Treat an undecryptable row as not-found so the caller re-auths instead
+  // of every request bubbling a 500 out of passport.deserializeUser.
+  try {
+    return toUser(row);
+  } catch (err) {
+    logger.warn(
+      `[userQueries] dropping unreadable user row spotify_id=${spotifyId}: ${errorMessage(err)}`,
+    );
+    return null;
+  }
 }
 
 async function updateUserAccessTokenBySpotifyId(


### PR DESCRIPTION
## Summary

Follow-up to #207. When `pool.query` returns a `users` row whose tokens can't be decrypted, `toUser()` throws inside `findUserBySpotifyId`. That throw bubbles through passport's `deserializeUser`, which runs on every authenticated request — so the user 500s on every endpoint, including `/api/auth/user/logout`. The cookie holds them in a state they can't escape from in-app, and the only recovery is clearing cookies in DevTools or wiping the `session` table on the droplet (#207's script).

This catches the decrypt error in `findUserBySpotifyId` and returns `null` instead. Passport sees no user, treats the session as anonymous, and the next interaction redirects to OAuth, where `findOrCreateUser`'s `ON CONFLICT … DO UPDATE` rewrites the row with freshly-encrypted tokens. A warning is logged so the recovery is visible in droplet logs.

How a row gets into this state:
- Legacy plaintext row left over from before #204 (the immediate trigger for this fix).
- Row encrypted under a since-rotated `TOKEN_ENCRYPTION_KEY` — `SUPABASE.md` already documents that rotating the key forces re-auth; this PR makes the re-auth happen automatically instead of via 500s.

The fix only touches the read path. `findOrCreateUser` and `updateUserAccessTokenBySpotifyId` write freshly-encrypted tokens before calling `toUser` on the `RETURNING` row, so they can't hit this path in normal flow and don't need the same treatment.

## Testing

- New `userQueries.test.ts` covers three cases: no row → null, valid row → user, decrypt-throws → null.
- `pnpm vitest run` server suite: 53 tests pass (was 50 before this PR; the 3 pre-existing test-file load failures are unrelated to this change — they fail on `main` too, due to `passport-spotify` requiring credentials at strategy construction).
- `pnpm typecheck` clean. `pnpm lint` clean for new files.