### PR TITLE
feat: add staging environment at staging.spune.tinney.dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
   pull_request:
     branches: [main]
 
@@ -150,7 +150,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Log in to GitHub Container Registry
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -164,13 +164,14 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=staging,enable=${{ github.ref == 'refs/heads/staging' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -108,6 +108,42 @@ Every request gets an `X-Request-Id` header (preserved from inbound when valid, 
 
 The server emits one `http_request` log line per response with `{ method, url, status, durationMs, requestId }`. `/api/health` (noise) and SSE streams (would record stream lifetime, not request work) are skipped.
 
+## Staging environment
+
+A shared staging environment runs at https://staging.spune.tinney.dev on the same droplet as production. It has its own Postgres volume, its own session/encryption secrets, and its own image tag (`ghcr.io/cdtinney/spune:staging`).
+
+### Deploying a branch to staging
+
+```bash
+git push origin <your-branch>:staging --force
+```
+
+This force-pushes your branch to the `staging` branch, which triggers CI to build and push `ghcr.io/cdtinney/spune:staging`. Watchtower (running in the prod stack) picks up the new image within ~60 seconds and restarts the staging app container.
+
+There is exactly one staging slot — whoever force-pushes most recently owns it. Coordinate via Slack/PR comments if multiple branches are in flight.
+
+### One-time setup (kept for reference)
+
+1. **DNS**: Cloudflare A record `staging.spune` pointing at the droplet IP, **DNS only** (grey cloud).
+2. **Spotify**: redirect URI `https://staging.spune.tinney.dev/api/auth/spotify/callback` added in the Spotify dashboard.
+3. **Droplet**:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/cdtinney/spune/main/scripts/setup-staging.sh | bash
+   ```
+4. **Caddy**: append the staging block to `/opt/spune/Caddyfile` and reload (the setup script prints the exact commands).
+5. **First start**: `cd /opt/spune-staging && docker compose up -d`, then run the user-table migration printed by the setup script.
+
+### Adding new env vars
+
+If you add a required env var, you must update **both** `/opt/spune/.env` and `/opt/spune-staging/.env` before merging to `main` / pushing to `staging`, otherwise the container will crash-loop after Watchtower picks up the new image.
+
+### Staging logs
+
+```bash
+cd /opt/spune-staging
+docker compose logs -f staging-app
+```
+
 ## Debugging
 
 ```bash

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -127,12 +127,18 @@ There is exactly one staging slot — whoever force-pushes most recently owns it
 
 1. **DNS**: Cloudflare A record `staging.spune` pointing at the droplet IP, **DNS only** (grey cloud).
 2. **Spotify**: redirect URI `https://staging.spune.tinney.dev/api/auth/spotify/callback` added in the Spotify dashboard.
-3. **Droplet**:
+3. **Droplet**: SSH in and run
    ```bash
    curl -fsSL https://raw.githubusercontent.com/cdtinney/spune/main/scripts/setup-staging.sh | bash
    ```
-4. **Caddy**: append the staging block to `/opt/spune/Caddyfile` and reload (the setup script prints the exact commands).
-5. **First start**: `cd /opt/spune-staging && docker compose up -d`, then run the user-table migration printed by the setup script.
+   This scaffolds `/opt/spune-staging/`, reuses the prod `.env`'s Spotify credentials, generates fresh secrets for the staging stack, and appends a `staging.spune.tinney.dev` site block to `/opt/spune/Caddyfile` (Caddy is reloaded).
+4. **First start**: push to `staging` (`pnpm deploy:staging`) so the `:staging` image exists, then on the droplet:
+   ```bash
+   cd /opt/spune-staging && docker compose up -d
+   docker compose exec -T staging-app \
+     sh -c 'cat /app/packages/server/src/database/migrations/*.sql' \
+     | docker compose exec -T staging-db psql -U spune -d spune
+   ```
 
 ### Adding new env vars
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -115,10 +115,11 @@ A shared staging environment runs at https://staging.spune.tinney.dev on the sam
 ### Deploying a branch to staging
 
 ```bash
-git push origin <your-branch>:staging --force
+pnpm deploy:staging              # deploys the current branch
+pnpm deploy:staging my-branch    # deploys a named branch
 ```
 
-This force-pushes your branch to the `staging` branch, which triggers CI to build and push `ghcr.io/cdtinney/spune:staging`. Watchtower (running in the prod stack) picks up the new image within ~60 seconds and restarts the staging app container.
+This wraps `git push origin <branch>:staging --force` with a confirmation prompt. The push triggers CI to build and push `ghcr.io/cdtinney/spune:staging`. Watchtower (running in the prod stack) picks up the new image within ~60 seconds and restarts the staging app container.
 
 There is exactly one staging slot — whoever force-pushes most recently owns it. Coordinate via Slack/PR comments if multiple branches are in flight.
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "client:test": "pnpm --filter spune-client test",
     "client:test:coverage": "pnpm --filter spune-client test:coverage",
     "client:watch": "pnpm --filter spune-client watch",
+    "deploy:staging": "./scripts/deploy-staging.sh",
     "dev": "docker compose -f docker-compose.dev.yml up -d && pnpm watch",
     "dev:stop": "docker compose -f docker-compose.dev.yml down",
     "format": "prettier --write .",

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Force-pushes a branch to `staging`, triggering a staging build & deploy.
+#
+# Usage:
+#   ./scripts/deploy-staging.sh              # deploys current branch
+#   ./scripts/deploy-staging.sh my-branch    # deploys named branch
+
+BRANCH="${1:-$(git rev-parse --abbrev-ref HEAD)}"
+
+if [ "$BRANCH" = "staging" ] || [ "$BRANCH" = "main" ]; then
+  echo "Refusing to deploy '$BRANCH' to staging."
+  exit 1
+fi
+
+if ! git rev-parse --verify "$BRANCH" >/dev/null 2>&1; then
+  echo "Error: branch '$BRANCH' does not exist locally."
+  exit 1
+fi
+
+SHA=$(git rev-parse --short "$BRANCH")
+SUBJECT=$(git log -1 --format=%s "$BRANCH")
+
+echo "About to deploy:"
+echo "  branch: $BRANCH"
+echo "  commit: $SHA — $SUBJECT"
+echo "  to:     origin/staging (force-push)"
+echo ""
+read -r -p "Continue? [y/N] " ANSWER
+case "$ANSWER" in
+  [yY] | [yY][eE][sS]) ;;
+  *)
+    echo "Aborted."
+    exit 0
+    ;;
+esac
+
+git push origin "${BRANCH}:staging" --force
+
+echo ""
+echo "Pushed. Watch the build:"
+echo "  https://github.com/cdtinney/spune/actions"
+echo ""
+echo "Once Watchtower picks up the new :staging image (~60s after CI succeeds):"
+echo "  https://staging.spune.tinney.dev"

--- a/scripts/setup-staging.sh
+++ b/scripts/setup-staging.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Sets up the staging environment alongside an existing prod setup at /opt/spune.
-# Run on the same droplet as prod, AFTER:
-#   1. DNS A record for staging.spune.tinney.dev points at this droplet
+# Sets up the staging environment alongside prod at /opt/spune.
+# Run on the droplet, AFTER:
+#   1. DNS A record for staging.spune.tinney.dev points here
 #   2. Spotify dashboard has https://staging.spune.tinney.dev/api/auth/spotify/callback
 #      added as a redirect URI
+#
+# Idempotent — safe to re-run.
 #
 # Usage (on droplet):
 #   curl -fsSL https://raw.githubusercontent.com/cdtinney/spune/main/scripts/setup-staging.sh | bash
@@ -17,11 +19,9 @@ if [ ! -d /opt/spune ]; then
   exit 1
 fi
 
-echo "==> Creating /opt/spune-staging..."
 mkdir -p /opt/spune-staging
 cd /opt/spune-staging
 
-echo "==> Writing docker-compose.yml..."
 cat > docker-compose.yml <<'COMPOSE'
 services:
   staging-db:
@@ -58,53 +58,30 @@ networks:
 COMPOSE
 
 if [ ! -f .env ]; then
-  echo "==> Generating .env..."
-  DB_PASSWORD=$(openssl rand -hex 16)
-
+  # shellcheck disable=SC1091
+  source /opt/spune/.env
   cat > .env <<EOF
-DB_PASSWORD=${DB_PASSWORD}
+DB_PASSWORD=$(openssl rand -hex 16)
 SESSION_SECRET=$(openssl rand -hex 32)
 TOKEN_ENCRYPTION_KEY=$(openssl rand -hex 32)
-SPOT_CLIENT_ID=REPLACE_ME
-SPOT_CLIENT_SECRET=REPLACE_ME
+SPOT_CLIENT_ID=${SPOT_CLIENT_ID}
+SPOT_CLIENT_SECRET=${SPOT_CLIENT_SECRET}
 SPOT_REDIRECT_URI=https://${DOMAIN}/api/auth/spotify/callback
 CLIENT_HOST=https://${DOMAIN}
-LAST_FM_API_KEY=
+LAST_FM_API_KEY=${LAST_FM_API_KEY:-}
 EOF
-else
-  echo "==> .env already exists, leaving it alone"
 fi
 
-echo ""
-echo "============================================"
-echo "  Staging stack scaffolded."
-echo "============================================"
-echo ""
-echo "Next steps:"
-echo ""
-echo "  1. Edit /opt/spune-staging/.env — copy SPOT_CLIENT_ID, SPOT_CLIENT_SECRET,"
-echo "     and LAST_FM_API_KEY values from /opt/spune/.env:"
-echo "       nano /opt/spune-staging/.env"
-echo ""
-echo "  2. Append the staging block to /opt/spune/Caddyfile and reload Caddy:"
-echo "       cat >> /opt/spune/Caddyfile <<'EOF'"
-echo ""
-echo "       ${DOMAIN} {"
-echo "           reverse_proxy spune-staging-app:5000"
-echo "       }"
-echo "       EOF"
-echo "       docker exec spune-caddy-1 caddy reload --config /etc/caddy/Caddyfile"
-echo ""
-echo "  3. Push your branch to trigger the first :staging image build:"
-echo "       git push origin <your-branch>:staging --force"
-echo ""
-echo "  4. Once CI has pushed the :staging image (~3 min), start the stack:"
-echo "       cd /opt/spune-staging && docker compose up -d"
-echo ""
-echo "  5. Run the user-table migration (one-time):"
-echo "       docker compose exec staging-db psql -U spune -d spune -c \\"
-echo "         \"CREATE TABLE IF NOT EXISTS users (id SERIAL PRIMARY KEY, spotify_id TEXT UNIQUE NOT NULL, spotify_access_token TEXT, spotify_refresh_token TEXT, token_updated BIGINT, expires_in BIGINT, display_name TEXT, photos JSON);\""
-echo ""
-echo "  6. Verify:"
-echo "       curl -s https://${DOMAIN}/api/health"
-echo ""
+if ! grep -q "^${DOMAIN} {" /opt/spune/Caddyfile; then
+  cat >> /opt/spune/Caddyfile <<EOF
+
+${DOMAIN} {
+    reverse_proxy spune-staging-app:5000
+}
+EOF
+  docker exec spune-caddy-1 caddy reload --config /etc/caddy/Caddyfile
+fi
+
+echo "Staging stack scaffolded at /opt/spune-staging/."
+echo "Next: push to staging (\`pnpm deploy:staging\`), then \`docker compose up -d\`"
+echo "and run the user-table migration. See docs/deployment.md."

--- a/scripts/setup-staging.sh
+++ b/scripts/setup-staging.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Sets up the staging environment alongside an existing prod setup at /opt/spune.
+# Run on the same droplet as prod, AFTER:
+#   1. DNS A record for staging.spune.tinney.dev points at this droplet
+#   2. Spotify dashboard has https://staging.spune.tinney.dev/api/auth/spotify/callback
+#      added as a redirect URI
+#
+# Usage (on droplet):
+#   curl -fsSL https://raw.githubusercontent.com/cdtinney/spune/main/scripts/setup-staging.sh | bash
+
+DOMAIN="staging.spune.tinney.dev"
+
+if [ ! -d /opt/spune ]; then
+  echo "Error: /opt/spune not found. Run setup-droplet.sh + setup-caddy.sh first."
+  exit 1
+fi
+
+echo "==> Creating /opt/spune-staging..."
+mkdir -p /opt/spune-staging
+cd /opt/spune-staging
+
+echo "==> Writing docker-compose.yml..."
+cat > docker-compose.yml <<'COMPOSE'
+services:
+  staging-db:
+    image: postgres:16-alpine
+    container_name: spune-staging-db
+    restart: always
+    environment:
+      POSTGRES_USER: spune
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: spune
+    volumes:
+      - pgdata-staging:/var/lib/postgresql/data
+
+  staging-app:
+    image: ghcr.io/cdtinney/spune:staging
+    container_name: spune-staging-app
+    restart: always
+    expose:
+      - "5000"
+    depends_on:
+      - staging-db
+    env_file: .env
+    environment:
+      NODE_ENV: production
+      DATABASE_URL: postgresql://spune:${DB_PASSWORD}@staging-db:5432/spune
+
+volumes:
+  pgdata-staging:
+
+networks:
+  default:
+    external: true
+    name: spune_default
+COMPOSE
+
+if [ ! -f .env ]; then
+  echo "==> Generating .env..."
+  DB_PASSWORD=$(openssl rand -hex 16)
+
+  cat > .env <<EOF
+DB_PASSWORD=${DB_PASSWORD}
+SESSION_SECRET=$(openssl rand -hex 32)
+TOKEN_ENCRYPTION_KEY=$(openssl rand -hex 32)
+SPOT_CLIENT_ID=REPLACE_ME
+SPOT_CLIENT_SECRET=REPLACE_ME
+SPOT_REDIRECT_URI=https://${DOMAIN}/api/auth/spotify/callback
+CLIENT_HOST=https://${DOMAIN}
+LAST_FM_API_KEY=
+EOF
+else
+  echo "==> .env already exists, leaving it alone"
+fi
+
+echo ""
+echo "============================================"
+echo "  Staging stack scaffolded."
+echo "============================================"
+echo ""
+echo "Next steps:"
+echo ""
+echo "  1. Edit /opt/spune-staging/.env — copy SPOT_CLIENT_ID, SPOT_CLIENT_SECRET,"
+echo "     and LAST_FM_API_KEY values from /opt/spune/.env:"
+echo "       nano /opt/spune-staging/.env"
+echo ""
+echo "  2. Append the staging block to /opt/spune/Caddyfile and reload Caddy:"
+echo "       cat >> /opt/spune/Caddyfile <<'EOF'"
+echo ""
+echo "       ${DOMAIN} {"
+echo "           reverse_proxy spune-staging-app:5000"
+echo "       }"
+echo "       EOF"
+echo "       docker exec spune-caddy-1 caddy reload --config /etc/caddy/Caddyfile"
+echo ""
+echo "  3. Push your branch to trigger the first :staging image build:"
+echo "       git push origin <your-branch>:staging --force"
+echo ""
+echo "  4. Once CI has pushed the :staging image (~3 min), start the stack:"
+echo "       cd /opt/spune-staging && docker compose up -d"
+echo ""
+echo "  5. Run the user-table migration (one-time):"
+echo "       docker compose exec staging-db psql -U spune -d spune -c \\"
+echo "         \"CREATE TABLE IF NOT EXISTS users (id SERIAL PRIMARY KEY, spotify_id TEXT UNIQUE NOT NULL, spotify_access_token TEXT, spotify_refresh_token TEXT, token_updated BIGINT, expires_in BIGINT, display_name TEXT, photos JSON);\""
+echo ""
+echo "  6. Verify:"
+echo "       curl -s https://${DOMAIN}/api/health"
+echo ""


### PR DESCRIPTION
## Summary

Adds a shared staging environment alongside prod on the same droplet.

- **Trigger**: force-push any branch to `staging` (`git push origin HEAD:staging --force`).
- **CI**: pushes on `staging` build and publish `ghcr.io/cdtinney/spune:staging` (separate from `:latest`). The existing Watchtower picks it up within ~60s.
- **Droplet**: a new `scripts/setup-staging.sh` scaffolds `/opt/spune-staging/` with its own Postgres volume, session secret, and encryption key. The staging compose joins the prod Docker network (`spune_default`) so the existing Caddy can reverse-proxy to it via container hostname `spune-staging-app`.
- **Caddy**: a single new site block on the existing Caddyfile handles `staging.spune.tinney.dev` (Let's Encrypt cert auto-fetched on first request).
- **Isolation**: separate DB, separate session secret, separate token encryption key. Sessions don't cross subdomains by default, so prod and staging cookies stay separate.

`deploy-check` stays main-only — no health gate on staging pushes.

## Testing

- DNS A record for `staging.spune.tinney.dev` already added (DNS-only, grey cloud)
- Staging redirect URI already added in the Spotify dashboard
- After this merges to `main`, on the droplet:
  - run `scripts/setup-staging.sh` and follow its printed steps (env vars, Caddyfile block, first `docker compose up -d`, migration)
  - force-push a branch to `staging` and watch Watchtower pick up the new image
  - hit `https://staging.spune.tinney.dev/api/health` and try a Spotify login round-trip