### PR TITLE
feat: add ALLOWED_SPOTIFY_IDS login allowlist

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -144,6 +144,19 @@ There is exactly one staging slot — whoever force-pushes most recently owns it
 
 If you add a required env var, you must update **both** `/opt/spune/.env` and `/opt/spune-staging/.env` before merging to `main` / pushing to `staging`, otherwise the container will crash-loop after Watchtower picks up the new image.
 
+### Restricting who can log in
+
+Set `ALLOWED_SPOTIFY_IDS` in `.env` to a comma-separated list of Spotify user IDs. When set, the OAuth callback rejects users not on the list and no user row is created for them. Leaving it unset (or empty) keeps login open to anyone with a Spotify account.
+
+For staging, set this on the droplet after running `setup-staging.sh`:
+
+```bash
+echo "ALLOWED_SPOTIFY_IDS=cdtinney" >> /opt/spune-staging/.env
+cd /opt/spune-staging && docker compose restart staging-app
+```
+
+Add additional comma-separated IDs to share staging with collaborators.
+
 ### Staging logs
 
 ```bash

--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -33,3 +33,9 @@ LAST_FM_API_KEY=
 # Leave empty to disable admin access entirely. Find your Spotify ID at
 # https://www.spotify.com/account/profile/ (look for the "Username" field).
 ADMIN_SPOTIFY_IDS=
+
+# Comma-separated Spotify user IDs allowed to log in at all. When unset (or
+# empty), anyone with a Spotify account can log in. When set, the OAuth
+# callback rejects users whose IDs aren't listed and no user row is created.
+# Useful for locking down staging or other non-public environments.
+ALLOWED_SPOTIFY_IDS=

--- a/packages/server/src/auth/__tests__/loginAllowlist.test.ts
+++ b/packages/server/src/auth/__tests__/loginAllowlist.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { isLoginAllowed } from '../loginAllowlist';
+
+describe('loginAllowlist', () => {
+  const original = process.env.ALLOWED_SPOTIFY_IDS;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.ALLOWED_SPOTIFY_IDS;
+    } else {
+      process.env.ALLOWED_SPOTIFY_IDS = original;
+    }
+  });
+
+  it.each([
+    { name: 'no allowlist set', allowlist: undefined, id: 'anyone', expected: true },
+    { name: 'empty allowlist', allowlist: '', id: 'anyone', expected: true },
+    { name: 'whitespace-only allowlist', allowlist: ' , , ', id: 'anyone', expected: true },
+    { name: 'ID in allowlist', allowlist: 'alice,bob', id: 'alice', expected: true },
+    { name: 'ID not in allowlist', allowlist: 'alice,bob', id: 'eve', expected: false },
+    {
+      name: 'allowlist with whitespace and empty entries',
+      allowlist: ' alice , , bob ,',
+      id: 'bob',
+      expected: true,
+    },
+  ])('returns $expected for $name', ({ allowlist, id, expected }) => {
+    if (allowlist === undefined) delete process.env.ALLOWED_SPOTIFY_IDS;
+    else process.env.ALLOWED_SPOTIFY_IDS = allowlist;
+    expect(isLoginAllowed(id)).toBe(expected);
+  });
+});

--- a/packages/server/src/auth/loginAllowlist.ts
+++ b/packages/server/src/auth/loginAllowlist.ts
@@ -1,0 +1,16 @@
+function parseAllowedIds(raw: string | undefined): Set<string> | null {
+  if (raw === undefined) return null;
+  const ids = new Set(
+    raw
+      .split(',')
+      .map((id) => id.trim())
+      .filter(Boolean),
+  );
+  return ids.size === 0 ? null : ids;
+}
+
+export function isLoginAllowed(spotifyId: string): boolean {
+  const allowed = parseAllowedIds(process.env.ALLOWED_SPOTIFY_IDS);
+  if (allowed === null) return true;
+  return allowed.has(spotifyId);
+}

--- a/packages/server/src/spotify/auth/__tests__/passportStrategy.test.ts
+++ b/packages/server/src/spotify/auth/__tests__/passportStrategy.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { verify } from '../passportStrategy';
 import { findOrCreateUser } from '../../../database/queries/userQueries';
 import type { User } from '../../../types';
@@ -21,6 +21,17 @@ const mockUser = { spotifyId: 'foo' } as User;
 
 describe('passportStrategy', () => {
   describe('verify', () => {
+    const originalAllowed = process.env.ALLOWED_SPOTIFY_IDS;
+
+    afterEach(() => {
+      vi.clearAllMocks();
+      if (originalAllowed === undefined) {
+        delete process.env.ALLOWED_SPOTIFY_IDS;
+      } else {
+        process.env.ALLOWED_SPOTIFY_IDS = originalAllowed;
+      }
+    });
+
     it('calls findOrCreateUser with the spotifyId', () => {
       mockedFindOrCreateUser.mockResolvedValue(mockUser);
       verify('token', 'refresh', 3600, mockProfile, vi.fn());
@@ -28,6 +39,33 @@ describe('passportStrategy', () => {
     });
 
     it('calls done() when the user is found or created', async () => {
+      mockedFindOrCreateUser.mockResolvedValue(mockUser);
+
+      await new Promise<void>((resolve) => {
+        verify('token', 'refresh', 3600, mockProfile, (err: Error | null, user: unknown) => {
+          expect(err).toBeNull();
+          expect(user).toEqual({ spotifyId: 'foo' });
+          resolve();
+        });
+      });
+    });
+
+    it('rejects login without creating a user when the id is not in ALLOWED_SPOTIFY_IDS', async () => {
+      process.env.ALLOWED_SPOTIFY_IDS = 'alice,bob';
+
+      await new Promise<void>((resolve) => {
+        verify('token', 'refresh', 3600, mockProfile, (err: Error | null, user: unknown) => {
+          expect(err).toBeNull();
+          expect(user).toBe(false);
+          resolve();
+        });
+      });
+
+      expect(mockedFindOrCreateUser).not.toHaveBeenCalled();
+    });
+
+    it('allows login when the id is in ALLOWED_SPOTIFY_IDS', async () => {
+      process.env.ALLOWED_SPOTIFY_IDS = 'foo,other';
       mockedFindOrCreateUser.mockResolvedValue(mockUser);
 
       await new Promise<void>((resolve) => {

--- a/packages/server/src/spotify/auth/passportStrategy.ts
+++ b/packages/server/src/spotify/auth/passportStrategy.ts
@@ -2,8 +2,15 @@ import { Strategy as SpotifyStrategy, type VerifyFunction } from 'passport-spoti
 import refresh from 'passport-oauth2-refresh';
 import logger from '../../logger';
 import { findOrCreateUser } from '../../database/queries/userQueries';
+import { isLoginAllowed } from '../../auth/loginAllowlist';
 
 const verify: VerifyFunction = (accessToken, refreshToken, expiresIn, profile, done): void => {
+  if (!isLoginAllowed(profile.id)) {
+    logger.warn(`Rejected login for ${profile.id} — not in ALLOWED_SPOTIFY_IDS.`);
+    done(null, false);
+    return;
+  }
+
   findOrCreateUser(profile.id, {
     spotifyAccessToken: accessToken,
     spotifyRefreshToken: refreshToken,

--- a/packages/server/src/spotify/auth/passportStrategy.ts
+++ b/packages/server/src/spotify/auth/passportStrategy.ts
@@ -5,6 +5,8 @@ import { findOrCreateUser } from '../../database/queries/userQueries';
 import { isLoginAllowed } from '../../auth/loginAllowlist';
 
 const verify: VerifyFunction = (accessToken, refreshToken, expiresIn, profile, done): void => {
+  // ALLOWED_SPOTIFY_IDS is per-environment — each Compose stack loads its own
+  // .env, so locking down staging never affects prod (and vice versa).
   if (!isLoginAllowed(profile.id)) {
     logger.warn(`Rejected login for ${profile.id} — not in ALLOWED_SPOTIFY_IDS.`);
     done(null, false);


### PR DESCRIPTION
## Summary

Mirrors the existing `ADMIN_SPOTIFY_IDS` pattern with a parallel `ALLOWED_SPOTIFY_IDS` env var that gates OAuth login itself. When set, the verify callback rejects unknown Spotify IDs (no user row created, redirect to the login page). When unset or empty, login stays open to anyone with a Spotify account — so this is a no-op for prod until the env var is added.

Primary use case: lock down staging without standing up Caddy basic_auth or an external identity provider.

## Testing

- New unit tests for `isLoginAllowed` covering unset, empty, whitespace-only, hit, miss, and dirty-formatting cases
- New `passportStrategy` tests verifying that rejected logins call `done(null, false)` without invoking `findOrCreateUser`, and that allowlisted IDs still flow through normally
- `pnpm --filter spune-server test --run` passes all 27 files / 92 tests
- `pnpm server:lint` and the server type check are clean
- After merge, set on the droplet and restart staging:
  ```bash
  echo "ALLOWED_SPOTIFY_IDS=cdtinney" >> /opt/spune-staging/.env
  cd /opt/spune-staging && docker compose restart staging-app
  ```