### PR TITLE
feat: add restrict:staging script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "client:test:coverage": "pnpm --filter spune-client test:coverage",
     "client:watch": "pnpm --filter spune-client watch",
     "deploy:staging": "./scripts/deploy-staging.sh",
+    "restrict:staging": "./scripts/restrict-staging.sh",
     "dev": "docker compose -f docker-compose.dev.yml up -d && pnpm watch",
     "dev:stop": "docker compose -f docker-compose.dev.yml down",
     "format": "prettier --write .",

--- a/scripts/restrict-staging.sh
+++ b/scripts/restrict-staging.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Sets ALLOWED_SPOTIFY_IDS in /opt/spune-staging/.env on the staging droplet
+# and restarts the staging-app container. Idempotent — replaces the existing
+# line if present, otherwise appends.
+#
+# Usage:
+#   ./scripts/restrict-staging.sh                       # default IDs: cdtinney
+#   ./scripts/restrict-staging.sh alice,bob,cdtinney    # custom IDs
+#   SPUNE_HOST=root@1.2.3.4 ./scripts/restrict-staging.sh
+
+IDS="${1:-cdtinney}"
+HOST="${SPUNE_HOST:-root@spune.tinney.dev}"
+
+if [[ ! "$IDS" =~ ^[a-zA-Z0-9_,-]+$ ]]; then
+  echo "Error: ALLOWED_SPOTIFY_IDS may only contain letters, digits, _, -, and commas."
+  exit 1
+fi
+
+ssh "$HOST" bash -s <<REMOTE
+set -euo pipefail
+ENV_FILE=/opt/spune-staging/.env
+
+if [ ! -f "\$ENV_FILE" ]; then
+  echo "Error: \$ENV_FILE not found. Run setup-staging.sh first." >&2
+  exit 1
+fi
+
+if grep -q '^ALLOWED_SPOTIFY_IDS=' "\$ENV_FILE"; then
+  sed -i "s|^ALLOWED_SPOTIFY_IDS=.*|ALLOWED_SPOTIFY_IDS=${IDS}|" "\$ENV_FILE"
+else
+  echo "ALLOWED_SPOTIFY_IDS=${IDS}" >> "\$ENV_FILE"
+fi
+
+cd /opt/spune-staging
+docker compose restart staging-app
+REMOTE
+
+echo "Set ALLOWED_SPOTIFY_IDS=${IDS} on staging and restarted the app."


### PR DESCRIPTION
## Summary

Wraps the two-step "set `ALLOWED_SPOTIFY_IDS` and restart staging-app" workflow as a single laptop-side command. SSHes into the droplet, edits `/opt/spune-staging/.env` (replacing the existing line if present, otherwise appending), and runs `docker compose restart staging-app`.

```bash
pnpm restrict:staging                    # ALLOWED_SPOTIFY_IDS=cdtinney
pnpm restrict:staging alice,bob,cdtinney # custom list
SPUNE_HOST=root@1.2.3.4 pnpm restrict:staging
```

Pairs with #211 (which adds the env var the server actually reads). This PR is independent of #211 — it only writes to a file and runs a container restart, both of which work regardless of whether the running staging image understands `ALLOWED_SPOTIFY_IDS` yet.

Defaults: `IDS=cdtinney`, `HOST=root@spune.tinney.dev`. Validates that input is alphanumeric + `,_-` only to keep the value safe to interpolate into `.env` and `sed`.

## Testing

- `bash -n scripts/restrict-staging.sh` (syntax-check) clean
- Format check clean
- Local dry run with a non-existent host returns the expected SSH error
- After both this and #211 land, run `pnpm restrict:staging` and confirm a non-allowlisted Spotify account is rejected at staging login (callback redirects to login page, no user row created)