### PR TITLE
docs: simplify deployment docs and trim contributing duplication

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,15 @@
+<!--
+Keep the PR description short. Aim for under ~500 characters total — no one
+reads long ones. Skip restating what the diff already shows. If you find
+yourself writing a section per file, the description is too long.
+-->
+
 ## Summary
 
-<!-- Brief description of what this PR does and why. -->
+<!-- One or two sentences: what this PR does and why. -->
 
 ## Testing
 
-<!-- How was this tested/how should it be tested? Use a list of bullet points, but not checkboxes/checklists. Omit unnecessary prefixes like "Verified..." -->
+<!-- Bullet points, no checkboxes. Skip prefixes like "Verified...". -->
 
 <!-- AI agent attribution is unnecessary for a personal project like this. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,10 @@
 
 This is a [pnpm](https://pnpm.io/) monorepo with two packages:
 
-| Package           | Name           | Description                                                              |
-| ----------------- | -------------- | ------------------------------------------------------------------------ |
-| `packages/client` | `spune-client` | React 19 + [Vite](https://vite.dev/) SPA                                 |
-| `packages/server` | `spune-server` | Express + [TypeScript](https://www.typescriptlang.org/) API              |
+| Package           | Name           | Description                                                 |
+| ----------------- | -------------- | ----------------------------------------------------------- |
+| `packages/client` | `spune-client` | React 19 + [Vite](https://vite.dev/) SPA                    |
+| `packages/server` | `spune-server` | Express + [TypeScript](https://www.typescriptlang.org/) API |
 
 ### Monorepo Structure
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,14 +4,14 @@
 
 ## Project Overview
 
-**Spune** is a Zune-inspired Spotify "Now Playing" visualizer. A React SPA polls a custom Express back-end for the currently playing track, then renders a Zune-style animated mosaic of related artist album covers as the background.
+**Spune** is a Zune-inspired [Spotify](https://www.spotify.com/) "Now Playing" visualizer. A [React](https://react.dev/) SPA polls a custom [Express](https://expressjs.com/) back-end for the currently playing track, then renders a Zune-style animated mosaic of related artist album covers as the background.
 
-This is a **pnpm monorepo** with two packages:
+This is a [pnpm](https://pnpm.io/) monorepo with two packages:
 
-| Package           | Name           | Description              |
-| ----------------- | -------------- | ------------------------ |
-| `packages/client` | `spune-client` | React 19 + Vite SPA      |
-| `packages/server` | `spune-server` | Express + TypeScript API |
+| Package           | Name           | Description                                                              |
+| ----------------- | -------------- | ------------------------------------------------------------------------ |
+| `packages/client` | `spune-client` | React 19 + [Vite](https://vite.dev/) SPA                                 |
+| `packages/server` | `spune-server` | Express + [TypeScript](https://www.typescriptlang.org/) API              |
 
 ### Monorepo Structure
 
@@ -38,6 +38,8 @@ packages/
       types/             # TypeScript types (user, spotify, external APIs)
 ```
 
+Key server dependencies: [Passport.js](https://www.passportjs.org/) (OAuth), [`lru-cache`](https://github.com/isaacs/node-lru-cache) (in-memory caches), [Winston](https://github.com/winstonjs/winston) (logging), [PostgreSQL](https://www.postgresql.org/) via [`pg`](https://node-postgres.com/).
+
 ## Architecture
 
 ### Client-Server Communication
@@ -56,7 +58,7 @@ The client polls `/api/spotify/me/player` every 3 seconds. When the album change
 
 ### Observability
 
-- **Request IDs**: every request gets an `X-Request-Id`. Trusted inbound IDs (alphanumeric, `_`, `.`, `:`, `-`, ≤128 chars) are preserved; otherwise a UUID is generated. The same value is echoed back as a response header and is attached to every Winston log entry emitted on that request via `AsyncLocalStorage`. To pull the current ID inside a handler, import `getRequestId` from `middleware/requestContext`.
+- **Request IDs**: every request gets an `X-Request-Id`. Trusted inbound IDs (alphanumeric, `_`, `.`, `:`, `-`, ≤128 chars) are preserved; otherwise a UUID is generated. The same value is echoed back as a response header and is attached to every Winston log entry emitted on that request via [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage). To pull the current ID inside a handler, import `getRequestId` from `middleware/requestContext`.
 - **Access logs**: `httpLogger` middleware emits one `http_request` log line per response with `{ method, url, status, durationMs }`. `/api/health` and SSE streams (`/api/sse/*`) are skipped — the former is noise, the latter would record stream lifetime instead of request work.
 
 ### Auth Flow
@@ -67,7 +69,7 @@ The client polls `/api/spotify/me/player` every 3 seconds. When the album change
 4. Passport verify callback upserts the user in PostgreSQL with access/refresh tokens
 5. Success redirects to `CLIENT_HOST/#/visualization`
 6. On every subsequent request, `deserializeUser` loads the user from DB by `spotifyId` stored in the session
-7. Token refresh: `apiRequestWithRefresh` checks if `tokenUpdated + expiresIn <= Date.now()` and refreshes via `passport-oauth2-refresh` if expired
+7. Token refresh: `apiRequestWithRefresh` checks if `tokenUpdated + expiresIn <= Date.now()` and refreshes via [`passport-oauth2-refresh`](https://github.com/fiznool/passport-oauth2-refresh) if expired
 
 ### Album Discovery Pipeline
 
@@ -84,11 +86,11 @@ Entry: `getCurrentlyPlayingRelatedAlbums(spotifyApi, songId)` in `packages/serve
 ## Key Conventions
 
 - **TypeScript**: `strict: true` in both packages. Client uses `noEmit` (Vite transpiles). Server compiles to CommonJS in `dist/`.
-- **Testing**: Vitest for both packages. Client uses `jsdom` environment + `@testing-library/react`. Server uses `node` environment. Tests live in `src/__tests__/` or `src/**/__tests__/`.
-- **Formatting**: Prettier (single quotes, trailing commas, 100 char width, 2-space indent). Run `pnpm format:check` to verify.
-- **Linting**: ESLint v9 flat config with `typescript-eslint` recommended. `eslint-config-prettier` disables style rules. Unused vars prefixed `_` are allowed.
+- **Testing**: [Vitest](https://vitest.dev/) for both packages. Client uses [`jsdom`](https://github.com/jsdom/jsdom) environment + [`@testing-library/react`](https://testing-library.com/docs/react-testing-library/intro/). Server uses `node` environment. Tests live in `src/__tests__/` or `src/**/__tests__/`.
+- **Formatting**: [Prettier](https://prettier.io/) (single quotes, trailing commas, 100 char width, 2-space indent). Run `pnpm format:check` to verify.
+- **Linting**: [ESLint](https://eslint.org/) v9 flat config with [`typescript-eslint`](https://typescript-eslint.io/) recommended. `eslint-config-prettier` disables style rules. Unused vars prefixed `_` are allowed.
 - **Package manager**: pnpm 10 with workspaces. Always use `pnpm`, never `npm` or `yarn`.
-- **Routing**: Hash-based routing (`HashRouter`) so the server only needs to serve `index.html`.
+- **Routing**: Hash-based routing ([`HashRouter`](https://reactrouter.com/api/components/HashRouter)) so the server only needs to serve `index.html`.
 
 ## Common Tasks
 
@@ -118,7 +120,7 @@ Entry: `getCurrentlyPlayingRelatedAlbums(spotifyApi, songId)` in `packages/serve
 - **Session cookie port mismatch**: In dev, `SPOT_REDIRECT_URI` must point to port 3000 (Vite), not 5000 (Express). The Vite proxy forwards the callback to Express, and the session cookie must be set on the origin the browser visits.
 - **dotenv load order**: `packages/server/app.ts` uses dynamic `import()` to ensure `dotenv.config()` runs before any module-level code reads `process.env`. Do not add top-level imports of modules that read env vars.
 - **Rate limiting disabled in dev**: All rate limiters in `packages/server/src/middleware/rateLimiter.ts` are passthrough when `NODE_ENV !== 'production'`.
-- **`trust proxy: 1`** is set in `createApp.ts` for Caddy reverse proxy in production. Don't remove this.
+- **`trust proxy: 1`** is set in `createApp.ts` for [Caddy](https://caddyserver.com/) reverse proxy in production. Don't remove this.
 - **`LAST_FM_API_KEY`** is optional. If unset, only ListenBrainz is used for related artist discovery.
 - **Client build output**: Goes to `packages/client/build/`, not the default `dist/`.
 - **Server tests need Spotify env vars**: Route tests that call `createApp()` require `SPOT_CLIENT_ID`, `SPOT_CLIENT_SECRET`, and `SPOT_REDIRECT_URI` to be set (any non-empty value works). The `scripts/pre-pr.sh` script sets test defaults automatically. CI also sets these in the `server` job.
@@ -129,7 +131,7 @@ Entry: `getCurrentlyPlayingRelatedAlbums(spotifyApi, songId)` in `packages/serve
 - **Update documentation**: When changing behavior, update AGENTS.md, README.md, and any relevant docs/ files. If adding a new feature, add it to the roadmap in docs/TODO.md.
 - **Reusable over one-off**: Extract shared helpers, hooks, and CSS classes instead of duplicating code. Check if a pattern already exists before creating a new one.
 - **Verbose, descriptive naming**: Prefer `mockFullVisualization` over `mockVis`, `useNowPlayingPoller` over `usePoller`, `visualization__bottom-gradient` over `viz__grad`. Names should be self-documenting.
-- **data-testid for E2E tests**: Add `data-testid` attributes to components that E2E tests target. Prefer `page.getByTestId()` over CSS class selectors in Playwright tests.
+- **data-testid for E2E tests**: Add `data-testid` attributes to components that E2E tests target. Prefer `page.getByTestId()` over CSS class selectors in [Playwright](https://playwright.dev/) tests.
 - **Visual regression coverage**: When changing UI layout or styling, run `pnpm test:e2e:docker` to verify no visual regressions. If a visual change is intentional, update baselines with `pnpm test:e2e:update-snapshots` and commit the new snapshots.
 
 ### Updating visual baselines after a UI change

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-See the [README](README.md) for full setup instructions. In short:
+See the [README](README.md) for full setup. Short version:
 
 ```bash
 git clone git@github.com:cdtinney/spune.git
@@ -15,90 +15,38 @@ pnpm dev
 
 ## Branch Naming
 
-Use the format: `task/NN-description`
-
-Examples:
-
-- `task/15-ai-agent-friendly`
-- `task/08-typescript-migration`
+`task/NN-description`, e.g. `task/15-ai-agent-friendly`.
 
 ## Commit Messages
 
-Use [Conventional Commits](https://www.conventionalcommits.org/):
-
-```
-feat: add related artist caching
-fix: correct session cookie domain in dev
-docs: update README setup instructions
-refactor: extract album dedup logic
-test: add tests for token refresh
-chore: update dependencies
-```
+Use [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`.
 
 ## PR Process
 
 1. Branch off `main`.
 2. Make your changes.
-3. Run the full check suite locally:
-   ```bash
-   ./scripts/pre-pr.sh
-   ```
-4. Push your branch and open a PR against `main`.
-5. CI must pass (format, lint, test, build).
-6. PRs are squash-merged.
+3. Run `./scripts/pre-pr.sh` (formatting, lint, tests, build, type-check for both packages — same as CI).
+4. Push and open a PR against `main`. CI must pass; PRs are squash-merged.
 
-## Running Checks Locally
-
-The `scripts/pre-pr.sh` script runs the full CI suite:
-
-```bash
-./scripts/pre-pr.sh
-```
-
-This runs formatting, linting, tests, build, and type-checking for both packages. Run this before pushing to catch issues early.
+Install the pre-commit hook (`./scripts/install-hooks.sh`) to run Prettier and ESLint on staged files before each commit.
 
 ## Code Quality
 
 ### CSS
 
-- **Use design tokens** — Shared colors, spacing, shadows, z-index layers, and border radius are defined as CSS custom properties in `packages/client/src/index.css` under `:root`. Always use `var(--token-name)` instead of hardcoding values like `#1db954` or `30px`.
-- **Use utility classes** before writing component-specific styles:
-  - `.btn-primary` — Spotify-green button with hover state
-  - `.icon-interactive` — Text color with dimmed hover/focus state for icon buttons and links
-  - `.focus-ring` — Spotify-green focus-visible outline for keyboard accessibility
-- **Don't redeclare inherited styles** — Page containers inherit `background-color` and `font-family` from `body`. Don't repeat them.
+- **Use design tokens** — Shared colors, spacing, shadows, z-index layers, and border radius are CSS custom properties in `packages/client/src/index.css` under `:root`. Use `var(--token-name)`, never hardcoded values like `#1db954` or `30px`.
+- **Use utility classes** before writing component-specific styles: `.btn-primary`, `.icon-interactive`, `.focus-ring`.
+- **Don't redeclare inherited styles** — Page containers inherit `background-color` and `font-family` from `body`.
 
 ### Naming
 
-- **Constants** — `SCREAMING_SNAKE_CASE` with descriptive names and units: `TILE_SIZE_PX`, `RESIZE_DEBOUNCE_MS`, not `BASE` or `300`.
-- **Booleans** — Props and interface fields use `is`/`has` prefixes (`isPlaying`, `hasError`). Local component state uses bare adjectives (`visible`, `open`).
-- **Callbacks** — Props use `on` prefix (`onClick`, `onLogout`). Internal handlers use `handle` prefix (`handleResize`).
+- **Constants** — `SCREAMING_SNAKE_CASE` with units: `TILE_SIZE_PX`, `RESIZE_DEBOUNCE_MS`.
+- **Booleans** — Props/interface fields use `is`/`has` prefixes (`isPlaying`, `hasError`); local state uses bare adjectives (`visible`, `open`).
+- **Callbacks** — Props use `on` (`onClick`); internal handlers use `handle` (`handleResize`).
 - **Action types** — Use the `ActionType` const object in `SpotifyContext.tsx`, not string literals.
 
 ### Avoiding Duplication
 
-- **Error extraction** — Use `errorMessage(error)` from `packages/server/src/utils/errorMessage.ts` instead of inlining `error instanceof Error` checks.
-- **Rate limiters** — Use `createLimiter(max, message)` in `rateLimiter.ts` to add new limiters.
-- **Test mocks** — Use `mockUseUser()` from `packages/client/src/__tests__/helpers/mockUserContext.ts` instead of repeating the full mock shape. Only pass overrides for what your test cares about.
-
-## Git Hooks
-
-Install the pre-commit hook to catch formatting and lint issues before they reach CI:
-
-```bash
-./scripts/install-hooks.sh
-```
-
-The hook runs Prettier and ESLint on staged files only, so it's fast. It does not run tests or type checks — those are covered by `pre-pr.sh` and CI.
-
-Individual checks:
-
-```bash
-pnpm format:check           # Prettier
-pnpm lint                   # ESLint (both packages)
-pnpm client:test            # Client tests
-pnpm server:test            # Server tests
-pnpm client:build           # Client build
-pnpm --filter spune-client exec tsc --noEmit  # Client types
-pnpm --filter spune-server exec tsc --noEmit  # Server types
-```
+- **Error extraction** — `errorMessage(error)` from `packages/server/src/utils/errorMessage.ts`.
+- **Rate limiters** — `createLimiter(max, message)` in `rateLimiter.ts`.
+- **Test mocks** — `mockUseUser()` from `packages/client/src/__tests__/helpers/mockUserContext.ts`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Use [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:
 3. Run `./scripts/pre-pr.sh` (formatting, lint, tests, build, type-check for both packages — same as CI).
 4. Push and open a PR against `main`. CI must pass; PRs are squash-merged.
 
-Install the pre-commit hook (`./scripts/install-hooks.sh`) to run Prettier and ESLint on staged files before each commit.
+Install the pre-commit hook (`./scripts/install-hooks.sh`) to run [Prettier](https://prettier.io/) and [ESLint](https://eslint.org/) on staged files before each commit.
 
 ## Code Quality
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 
 ## Overview
 
-Spune displays album artwork from related artists in a Zune-style mosaic while you listen to Spotify. It discovers related artists via Last.fm and ListenBrainz, renders their album covers as an animated background, and can cast the visualization to a TV via Chromecast.
+Spune displays album artwork from related artists in a Zune-style mosaic while you listen to [Spotify](https://www.spotify.com/). It discovers related artists via [Last.fm](https://www.last.fm/api) and [ListenBrainz](https://listenbrainz.org/), renders their album covers as an animated background, and can cast the visualization to a TV via [Chromecast](https://store.google.com/product/chromecast_google_tv).
 
 ### Stack
 
-- **Client**: React 19, Vite, TypeScript — [details](packages/client/README.md)
-- **Server**: Node.js, Express, TypeScript, PostgreSQL — [details](packages/server/README.md)
-- **APIs**: Spotify Web API, Last.fm, ListenBrainz/MusicBrainz
-- **CI/CD**: GitHub Actions, Docker, GHCR
+- **Client**: [React 19](https://react.dev/), [Vite](https://vite.dev/), [TypeScript](https://www.typescriptlang.org/) — [details](packages/client/README.md)
+- **Server**: [Node.js](https://nodejs.org/), [Express](https://expressjs.com/), TypeScript, [PostgreSQL](https://www.postgresql.org/) — [details](packages/server/README.md)
+- **APIs**: [Spotify Web API](https://developer.spotify.com/documentation/web-api), Last.fm, ListenBrainz / [MusicBrainz](https://musicbrainz.org/)
+- **CI/CD**: [GitHub Actions](https://docs.github.com/en/actions), Docker, [GHCR](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
 
 ## Development Setup
 

--- a/docs/chromecast.md
+++ b/docs/chromecast.md
@@ -1,6 +1,6 @@
 # Chromecast Integration
 
-Spune can cast the album art visualization to a Chromecast-enabled TV — the original Zune living room experience.
+Spune can cast the album art visualization to a [Chromecast](https://store.google.com/product/chromecast_google_tv)-enabled TV — the original Zune living room experience.
 
 ## How it works
 
@@ -8,7 +8,7 @@ Spune can cast the album art visualization to a Chromecast-enabled TV — the or
 
 The sender runs in the browser (Chrome only). When a Chromecast is detected on the local network, a cast icon appears in the bottom-right corner of the visualization page.
 
-1. The Google Cast Sender SDK is loaded on page mount.
+1. The [Google Cast Sender SDK](https://developers.google.com/cast/docs/web_sender) is loaded on page mount.
 2. The SDK discovers Chromecast devices that support the configured app ID.
 3. Clicking the cast button opens Chrome's device picker.
 4. Once connected, the sender pushes playback data to the receiver on every poll update (every 3 seconds):
@@ -51,7 +51,7 @@ interface CastMessage {
 
 ## Setup
 
-### 1. Google Cast Developer Console
+### 1. [Google Cast Developer Console](https://cast.google.com/publish/)
 
 1. Go to [cast.google.com/publish](https://cast.google.com/publish/).
 2. Pay the $5 one-time developer fee (if not already done).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,183 +1,100 @@
 # Production Deployment
 
-CI auto-builds and pushes a Docker image to `ghcr.io` on every merge to `main`. The droplet auto-updates via Watchtower.
+CI builds a Docker image on every merge to `main` and pushes it to `ghcr.io`. Watchtower on the droplet pulls the new image within ~60s and restarts the app. CI's `deploy-check` job then polls `GET /api/status` until the running version matches the new commit SHA.
 
-## Setup
-
-### 1. Create the droplet
-
-Create an Ubuntu 24.04 DigitalOcean droplet (1GB RAM is enough). Open the **Droplet Console** and run:
+To verify a deploy manually:
 
 ```bash
+./scripts/check-deploy.sh https://spune.tinney.dev/api/status <commit-sha>
+```
+
+## First-time droplet setup
+
+On a fresh Ubuntu 24.04 DigitalOcean droplet (1GB RAM is enough):
+
+```bash
+# 1. Install Docker, scaffold /opt/spune, generate secrets
 curl -fsSL https://raw.githubusercontent.com/cdtinney/spune/main/scripts/setup-droplet.sh | bash
+
+# 2. Log in to GHCR (token: github.com/settings/tokens, classic, read:packages)
+echo "$GHCR_TOKEN" | docker login ghcr.io -u <github-username> --password-stdin
+
+# 3. Fill in Spotify + Last.fm credentials
+nano /opt/spune/.env
+
+# 4. Start the stack and run migrations
+cd /opt/spune && docker compose up -d
+sleep 10
+curl -fsSL https://raw.githubusercontent.com/cdtinney/spune/main/scripts/migrate.sh | bash
+
+# 5. Add HTTPS (point your domain's A record at the droplet IP first; Cloudflare proxy must be DNS-only)
+curl -fsSL https://raw.githubusercontent.com/cdtinney/spune/main/scripts/setup-caddy.sh -o /tmp/setup-caddy.sh
+bash /tmp/setup-caddy.sh your-domain.com
 ```
 
-This installs Docker, creates `/opt/spune` with a `docker-compose.yml` and `.env`, and generates random secrets.
+Add `https://your-domain.com/api/auth/spotify/callback` to the Spotify app's redirect URIs.
 
-### 2. Configure credentials
+## Adding a required env var
 
-Log in to GitHub Container Registry:
+The server validates required secrets at boot and refuses to start in production if any are missing. When a PR adds a new required env var, append it to `/opt/spune/.env` **and** `/opt/spune-staging/.env` before merging, otherwise Watchtower will pick up the new image and crash-loop.
 
-1. Create a [personal access token](https://github.com/settings/tokens) (classic, `read:packages` scope).
-2. Run on the droplet:
-
-```bash
-echo "ghp_yourTokenHere" | docker login ghcr.io -u your-github-username --password-stdin
-```
-
-Edit `/opt/spune/.env` and fill in your Spotify + Last.fm credentials.
-
-### 3. Point your domain
-
-Add an **A record** in your DNS provider pointing to the droplet IP.
-
-**Cloudflare**: set proxy status to **DNS only** (grey cloud). Caddy handles SSL.
-
-### 4. Start and migrate
-
-```bash
-cd /opt/spune
-docker compose up -d
-# Wait ~10s for Postgres, then:
-curl -fsSL https://raw.githubusercontent.com/cdtinney/spune/main/scripts/migrate.sh -o /tmp/migrate.sh && bash /tmp/migrate.sh
-```
-
-### 5. Add HTTPS
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/cdtinney/spune/main/scripts/setup-caddy.sh -o /tmp/setup-caddy.sh && bash /tmp/setup-caddy.sh your-domain.com
-```
-
-Add `https://your-domain.com/api/auth/spotify/callback` to your Spotify app's redirect URIs.
-
-## Auto-deploy
-
-1. Merge a PR to `main`
-2. CI builds and pushes `ghcr.io/cdtinney/spune:latest`
-3. Watchtower detects the new image within 60 seconds
-4. It pulls and restarts the app container
-
-### Adding new required env vars
-
-The server validates required secrets at boot in production and refuses to start if any are missing. When a PR adds a new required env var, add it to `/opt/spune/.env` on the droplet **before merging** so the next auto-deploy doesn't crash-loop.
-
-For example, when token encryption was introduced, existing droplets needed:
+Example (token encryption rollout):
 
 ```bash
 echo "TOKEN_ENCRYPTION_KEY=$(openssl rand -hex 32)" >> /opt/spune/.env
 docker compose restart app
 ```
 
-Existing user rows with plaintext tokens won't decrypt and the affected users will be forced to re-auth once.
+## Staging
 
-### Deploy verification
+Shared staging at https://staging.spune.tinney.dev runs on the same droplet with its own DB volume, secrets, and image tag (`ghcr.io/cdtinney/spune:staging`).
 
-CI includes a `deploy-check` job that polls `GET /api/status` after the Docker image is pushed, waiting for the running version to match the new commit SHA.
-
-You can also run the check manually:
+Deploy a branch:
 
 ```bash
-./scripts/check-deploy.sh https://spune.tinney.dev/api/status <commit-sha>
+pnpm deploy:staging              # current branch
+pnpm deploy:staging my-branch    # named branch
 ```
 
-### Status endpoint
+This force-pushes to `origin/staging` (with confirmation), CI builds `:staging`, Watchtower picks it up. Only one slot — coordinate via Slack/PR comments.
 
-`GET /api/status` returns:
+**One-time setup** (already done; for reference):
 
-```json
-{
-  "version": "abc1234...",
-  "uptime": 12345.67,
-  "startedAt": "2025-01-01T00:00:00.000Z"
-}
-```
-
-- **version**: The commit SHA baked into the Docker image at build time
-- **uptime**: Seconds since the Node.js process started
-- **startedAt**: ISO timestamp of when the process started
-
-Rate-limited to 30 requests per 15 minutes.
-
-### Health endpoint
-
-`GET /api/health` returns `200 { "status": "ok" }` when the server can reach PostgreSQL via `SELECT 1` within ~2s, or `503 { "status": "error" }` otherwise. Not rate-limited; safe for an external uptime monitor to poll. When the check fails, the underlying error is logged at `warn` level under `[health] DB check failed`.
-
-### Request IDs and access logs
-
-Every request gets an `X-Request-Id` header (preserved from inbound when valid, otherwise generated). The same value is echoed back to the client and included in every server log entry on that request, so a single ID can correlate a client report with the matching log lines.
-
-The server emits one `http_request` log line per response with `{ method, url, status, durationMs, requestId }`. `/api/health` (noise) and SSE streams (would record stream lifetime, not request work) are skipped.
-
-## Staging environment
-
-A shared staging environment runs at https://staging.spune.tinney.dev on the same droplet as production. It has its own Postgres volume, its own session/encryption secrets, and its own image tag (`ghcr.io/cdtinney/spune:staging`).
-
-### Deploying a branch to staging
-
-```bash
-pnpm deploy:staging              # deploys the current branch
-pnpm deploy:staging my-branch    # deploys a named branch
-```
-
-This wraps `git push origin <branch>:staging --force` with a confirmation prompt. The push triggers CI to build and push `ghcr.io/cdtinney/spune:staging`. Watchtower (running in the prod stack) picks up the new image within ~60 seconds and restarts the staging app container.
-
-There is exactly one staging slot — whoever force-pushes most recently owns it. Coordinate via Slack/PR comments if multiple branches are in flight.
-
-### One-time setup (kept for reference)
-
-1. **DNS**: Cloudflare A record `staging.spune` pointing at the droplet IP, **DNS only** (grey cloud).
-2. **Spotify**: redirect URI `https://staging.spune.tinney.dev/api/auth/spotify/callback` added in the Spotify dashboard.
-3. **Droplet**: SSH in and run
+1. DNS A record `staging.spune` → droplet IP, Cloudflare DNS-only.
+2. Spotify dashboard: add `https://staging.spune.tinney.dev/api/auth/spotify/callback`.
+3. On the droplet:
    ```bash
    curl -fsSL https://raw.githubusercontent.com/cdtinney/spune/main/scripts/setup-staging.sh | bash
-   ```
-   This scaffolds `/opt/spune-staging/`, reuses the prod `.env`'s Spotify credentials, generates fresh secrets for the staging stack, and appends a `staging.spune.tinney.dev` site block to `/opt/spune/Caddyfile` (Caddy is reloaded).
-4. **First start**: push to `staging` (`pnpm deploy:staging`) so the `:staging` image exists, then on the droplet:
-   ```bash
+   pnpm deploy:staging                       # build the :staging image (run from your laptop)
    cd /opt/spune-staging && docker compose up -d
-   docker compose exec -T staging-app \
-     sh -c 'cat /app/packages/server/src/database/migrations/*.sql' \
-     | docker compose exec -T staging-db psql -U spune -d spune
+   curl -fsSL https://raw.githubusercontent.com/cdtinney/spune/main/scripts/migrate-staging.sh | bash
    ```
-
-### Adding new env vars
-
-If you add a required env var, you must update **both** `/opt/spune/.env` and `/opt/spune-staging/.env` before merging to `main` / pushing to `staging`, otherwise the container will crash-loop after Watchtower picks up the new image.
 
 ### Restricting who can log in
 
-Set `ALLOWED_SPOTIFY_IDS` in `.env` to a comma-separated list of Spotify user IDs. When set, the OAuth callback rejects users not on the list and no user row is created for them. Leaving it unset (or empty) keeps login open to anyone with a Spotify account.
-
-For staging, set this on the droplet after running `setup-staging.sh`:
+Set `ALLOWED_SPOTIFY_IDS` in `.env` to a comma-separated list of Spotify user IDs. When set, the OAuth callback rejects users not on the list and no user row is created. Unset/empty keeps login open to anyone with a Spotify account. Each stack reads its own `.env`, so locking down staging doesn't affect prod.
 
 ```bash
 echo "ALLOWED_SPOTIFY_IDS=cdtinney" >> /opt/spune-staging/.env
 cd /opt/spune-staging && docker compose restart staging-app
 ```
 
-Add additional comma-separated IDs to share staging with collaborators.
-
-### Staging logs
-
-```bash
-cd /opt/spune-staging
-docker compose logs -f staging-app
-```
-
 ## Debugging
 
 ```bash
 cd /opt/spune
-docker compose logs --tail 100 app   # View app logs
-docker compose logs -f app           # Follow logs
-docker compose ps                     # Container status
-docker compose restart app            # Restart app
+docker compose logs --tail 100 app
+docker compose logs -f app
+docker compose ps
+docker compose restart app
 ```
+
+For staging, swap `/opt/spune` for `/opt/spune-staging` and the service name `app` for `staging-app`.
 
 ## Common issues
 
-- **"Internal Server Error" after login**: `SPOT_REDIRECT_URI` in `.env` doesn't match the Spotify dashboard.
-- **"DB_PASSWORD variable is not set"**: Check `/opt/spune/.env` has `DB_PASSWORD`.
-- **DB connection errors after changing password**: Reset the volume: `docker compose down -v && docker compose up -d`, then re-run migrations.
-- **Browser security warning on bare IP**: Use a domain with HTTPS (step 5).
-- **Login redirects to home**: `SPOT_REDIRECT_URI` and `CLIENT_HOST` must use the same origin.
+- **"Internal Server Error" after login** — `SPOT_REDIRECT_URI` in `.env` doesn't match the Spotify dashboard.
+- **"DB_PASSWORD variable is not set"** — missing in `/opt/spune/.env`.
+- **DB connection errors after changing password** — reset the volume: `docker compose down -v && docker compose up -d`, then re-run migrations.
+- **Login redirects to home** — `SPOT_REDIRECT_URI` and `CLIENT_HOST` must share an origin.
+- **Browser security warning on bare IP** — finish step 5 (HTTPS).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,6 @@
 # Production Deployment
 
-CI builds a Docker image on every merge to `main` and pushes it to `ghcr.io`. Watchtower on the droplet pulls the new image within ~60s and restarts the app. CI's `deploy-check` job then polls `GET /api/status` until the running version matches the new commit SHA.
+CI builds a [Docker](https://docs.docker.com/get-started/) image on every merge to `main` and pushes it to [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) (`ghcr.io`). [Watchtower](https://containrrr.dev/watchtower/) on the droplet pulls the new image within ~60s and restarts the app. CI's `deploy-check` job then polls `GET /api/status` until the running version matches the new commit SHA.
 
 To verify a deploy manually:
 
@@ -10,7 +10,7 @@ To verify a deploy manually:
 
 ## First-time droplet setup
 
-On a fresh Ubuntu 24.04 DigitalOcean droplet (1GB RAM is enough):
+On a fresh Ubuntu 24.04 [DigitalOcean](https://www.digitalocean.com/products/droplets) droplet (1GB RAM is enough). Step 5 installs [Caddy](https://caddyserver.com/) as a reverse proxy and obtains a Let's Encrypt certificate; if you use [Cloudflare](https://www.cloudflare.com/) for DNS, the A record must be "DNS only" (grey cloud), not proxied, so Caddy can complete the ACME challenge.
 
 ```bash
 # 1. Install Docker, scaffold /opt/spune, generate secrets
@@ -27,7 +27,7 @@ cd /opt/spune && docker compose up -d
 sleep 10
 curl -fsSL https://raw.githubusercontent.com/cdtinney/spune/main/scripts/migrate.sh | bash
 
-# 5. Add HTTPS (point your domain's A record at the droplet IP first; Cloudflare proxy must be DNS-only)
+# 5. Add HTTPS via Caddy (point your A record first; see note above).
 curl -fsSL https://raw.githubusercontent.com/cdtinney/spune/main/scripts/setup-caddy.sh -o /tmp/setup-caddy.sh
 bash /tmp/setup-caddy.sh your-domain.com
 ```

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+#
+# Install the project pre-commit hook into .git/hooks.
+# Run once after cloning the repo (or after the hook script changes).
+# The hook runs Prettier + ESLint on staged files only.
 set -e
 
 HOOK_DIR="$(git rev-parse --git-common-dir)/hooks"

--- a/scripts/migrate-staging.sh
+++ b/scripts/migrate-staging.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /opt/spune-staging
+
+echo "==> Waiting for staging database..."
+until docker compose exec -T staging-db pg_isready -U spune 2>/dev/null; do
+  sleep 1
+done
+
+echo "==> Running migrations..."
+docker compose exec -T staging-app \
+  sh -c 'cat /app/packages/server/src/database/migrations/*.sql' \
+  | docker compose exec -T staging-db psql -U spune -d spune
+
+echo "==> Migrations complete."

--- a/scripts/migrate-staging.sh
+++ b/scripts/migrate-staging.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+#
+# Apply SQL migrations to the staging database at /opt/spune-staging.
+# Run on the droplet once after `setup-staging.sh` (first-start migration), and
+# again after pulling a staging build that adds new migration files.
+# Same idempotency caveat as scripts/migrate.sh.
 set -euo pipefail
 
 cd /opt/spune-staging

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+#
+# Apply all SQL migrations to the production database on the droplet.
+# Run on the droplet during first-time setup, and again after pulling a
+# release that adds new files under packages/server/src/database/migrations/.
+# Migrations are written with CREATE ... IF NOT EXISTS-style guards so re-runs
+# are non-destructive, but check the SQL before re-running.
 set -euo pipefail
 
 echo "==> Waiting for database..."

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+#
+# Pre-commit hook: runs Prettier and ESLint on staged files only.
+# Installed into .git/hooks/pre-commit by scripts/install-hooks.sh — do not invoke directly.
+# Fast (touches only staged files); does not run tests or type checks.
 set -e
 
 STAGED=$(git diff --cached --name-only --diff-filter=ACMR)

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+#
+# Run the full local validation suite — the same checks CI runs on every PR.
+# Run before pushing a branch or opening a PR. Stops on the first failure.
+# Steps: format check, lint, client tests, server tests, client build, type-check both packages.
 set -euo pipefail
 
 # Server route tests need Spotify env vars (any non-empty value works for tests).


### PR DESCRIPTION
## Summary

Trim docs duplication, link tools/services on first mention, and give every script a short "what + when" header.

- `docs/deployment.md` 170 → 92 lines (dropped sections already covered in AGENTS.md, merged duplicate env-var notes)
- `CONTRIBUTING.md` 104 → 52 lines (removed sections that restated the README + pre-pr.sh)
- New `scripts/migrate-staging.sh`; new template note asking PR authors to keep descriptions short

## Testing

- Spot-checked all `raw.githubusercontent.com/.../scripts/...sh` URLs against `scripts/`
- Confirmed no Markdown links live inside fenced code blocks (they wouldn't render)